### PR TITLE
Rename module to github.com/redhat-developer/odo-fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/odo
+module github.com/redhat-developer/odo-fork
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/openshift/odo/common"
+	"github.com/redhat-developer/odo-fork/common"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Renames the module to `github.com/redhat-developer/odo-fork` so that dependency resolution should work out of the box.