### PR TITLE
Implement the KDO catalog and iterative-dev packs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
+	github.com/kubernetes-incubator/service-catalog v0.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.2
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/posener/complete v1.2.1
 	github.com/spf13/cobra v0.0.5

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,92 +1,114 @@
 package catalog
 
 import (
-	"fmt"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
 )
 
-type CatalogImage struct {
-	Name          string
-	Namespace     string
-	AllTags       []string
-	NonHiddenTags []string
+const DefaultIDPRepo = "https://raw.githubusercontent.com/johnmcollier/iterative-dev-packs/master/index.json"
+
+// CatalogEntry represents an entry in the index.json file for IDPs
+type CatalogEntry struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Language    string            `json:"language"`
+	Framework   string            `json:"framework"`
+	Devpacks    map[string]string `json:"devpacks"`
 }
 
-// List lists all the available component types
-func List(client *kclient.Client) ([]CatalogImage, error) {
+// List lists all the available Iterative-Dev Packs
+func List() ([]CatalogEntry, error) {
+	// See if we have an index.json already cached
+	var idpList []CatalogEntry
+	indexJSONFile := path.Join(os.TempDir(), ".kdo", "index.json")
 
-	// TODO: implement for KDO
-	fake := CatalogImage{"nodejs", "fakeNS", []string{"latest"}, []string{}}
-	catalogList := []CatalogImage{fake}
-
-	if len(catalogList) == 0 {
-		return nil, errors.New("unable to retrieve any catalog images from the OpenShift cluster")
+	// Load the index.json file into memory
+	var jsonBytes []byte
+	if _, err := os.Stat(indexJSONFile); os.IsNotExist(err) {
+		jsonBytes, err = downloadIDPs()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		file, err := os.Open(indexJSONFile)
+		if err != nil {
+			return nil, err
+		}
+		jsonBytes, err = ioutil.ReadAll(file)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return catalogList, nil
+	err := json.Unmarshal(jsonBytes, &idpList)
+	return idpList, err
 }
 
-// Search searches for the component
-func Search(client *kclient.Client, name string) ([]string, error) {
+// Search searches for the IDP in the catalog
+func Search(name string) ([]string, error) {
 	var result []string
-	componentList, err := List(client)
+	idpList, err := List()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list components")
+		return nil, errors.Wrap(err, "unable to list Iterative-Dev Packs")
 	}
 
-	// do a partial search in all the components
-	for _, component := range componentList {
-		// we only show components that contain the search term and that have at least non-hidden tag
-		// since a component with all hidden tags is not shown in the odo catalog list components either
-		if strings.Contains(component.Name, name) && len(component.NonHiddenTags) > 0 {
-			result = append(result, component.Name)
+	// do a partial search in all the Iterative-Dev Packs
+	for _, idp := range idpList {
+		// we only show IDP entries that contain the search term in their name and that have at least one devpack yaml linked
+		if strings.Contains(idp.Name, name) {
+			result = append(result, idp.Name)
 		}
 	}
 
 	return result, nil
 }
 
-// Exists returns true if the given component type is valid, false if not
-func Exists(client *kclient.Client, componentType string) (bool, error) {
+// Exists returns true if the given iterative-dev pack type is valid, false if not
+func Exists(idpType string) (bool, error) {
 
-	catalogList, err := List(client)
+	catalogList, err := List()
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to list catalog")
 	}
 
 	for _, supported := range catalogList {
-		if componentType == supported.Name || componentType == fmt.Sprintf("%s/%s", supported.Namespace, supported.Name) {
+		if idpType == supported.Name {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-// VersionExists checks if that version exists, returns true if the given version exists, false if not
-func VersionExists(client *kclient.Client, componentType string, componentVersion string) (bool, error) {
+// VersionExists checks if a IDP of the specified name and version exists
+func VersionExists(client *kclient.Client, idpType string, idpVersion string) (bool, error) {
 
 	// Loading status
-	glog.V(4).Info("Checking component version")
+	glog.V(4).Info("Checking Iterative-Dev pack version")
 
 	// Retrieve the catalogList
-	catalogList, err := List(client)
+	catalogList, err := List()
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to list catalog")
 	}
 
-	// Find the component and then return true if the version has been found
+	// Find the IDP and then return true if the version has been found
 	for _, supported := range catalogList {
-		if componentType == supported.Name || componentType == fmt.Sprintf("%s/%s", supported.Namespace, supported.Name) {
-			// Now check to see if that version matches that components tag
+		if idpType == supported.Name {
+			// Now check to see if that version matches that IDP's version
 			// here we use the AllTags, because if the user somehow got hold of a version that was hidden
 			// then it's safe to assume that this user went to a lot of trouble to actually use that version,
 			// so let's allow it
-			for _, tag := range supported.AllTags {
-				if componentVersion == tag {
+			for version := range supported.Devpacks {
+				if idpVersion == version {
 					return true, nil
 				}
 			}
@@ -95,4 +117,21 @@ func VersionExists(client *kclient.Client, componentType string, componentVersio
 
 	// Else return false if nothing is found
 	return false, nil
+}
+
+// downloadIDPs downloads the index.json to a temp directory for KDO to access
+func downloadIDPs() ([]byte, error) {
+	// Download the IDP index.json
+	var httpClient = &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get(DefaultIDPRepo)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	jsonBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return jsonBytes, err
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -479,7 +479,7 @@ func ValidateComponentCreateRequest(client *kclient.Client, componentSettings co
 	_, componentType, _, componentVersion := util.ParseComponentImageName(*componentSettings.Type)
 
 	// Check to see if the catalog type actually exists
-	exists, err := catalog.Exists(client, componentType)
+	exists, err := catalog.Exists(componentType)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create component of type %s", componentType)
 	}

--- a/pkg/kdo/cli/catalog/catalog.go
+++ b/pkg/kdo/cli/catalog/catalog.go
@@ -1,0 +1,36 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/catalog/list"
+	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/catalog/search"
+	kdoutil "github.com/redhat-developer/odo-fork/pkg/kdo/util"
+
+	"github.com/spf13/cobra"
+)
+
+// RecommendedCommandName is the recommended catalog command name
+const RecommendedCommandName = "catalog"
+
+// NewCmdCatalog implements the odo catalog command
+func NewCmdCatalog(name, fullName string) *cobra.Command {
+	catalogListCmd := list.NewCmdCatalogList(list.RecommendedCommandName, kdoutil.GetFullName(fullName, list.RecommendedCommandName))
+	catalogSearchCmd := search.NewCmdCatalogSearch(search.RecommendedCommandName, kdoutil.GetFullName(fullName, search.RecommendedCommandName))
+	catalogCmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s [options]", name),
+		Short: "Catalog related operations",
+		Long:  "Catalog related operations",
+		Example: fmt.Sprintf("%s\n%s\n",
+			catalogListCmd.Example,
+			catalogSearchCmd.Example),
+	}
+
+	catalogCmd.AddCommand(catalogListCmd, catalogSearchCmd)
+
+	// Add a defined annotation in order to appear in the help menu
+	catalogCmd.Annotations = map[string]string{"command": "main"}
+	catalogCmd.SetUsageTemplate(kdoutil.CmdUsageTemplate)
+
+	return catalogCmd
+}

--- a/pkg/kdo/cli/catalog/list/idp.go
+++ b/pkg/kdo/cli/catalog/list/idp.go
@@ -1,0 +1,78 @@
+package list
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/redhat-developer/odo-fork/pkg/catalog"
+	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
+	"github.com/spf13/cobra"
+)
+
+const idpRecommendedCommandName = "idp"
+
+var idpsExample = `  # Get the supported Iterative-dev Packs`
+
+// ListIDPOptions encapsulates the options for the kdo catalog list idp command
+type ListIDPOptions struct {
+	// list of known images
+	catalogList []catalog.CatalogEntry
+	// generic context options common to all commands
+	*genericclioptions.Context
+}
+
+// NewListIDPOptions creates a new ListIDPOptions instance
+func NewListIDPOptions() *ListIDPOptions {
+	return &ListIDPOptions{}
+}
+
+// Complete completes ListIDPOptions after they've been created
+func (o *ListIDPOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.Context = genericclioptions.NewContext(cmd)
+	o.catalogList, err = catalog.List()
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
+// Validate validates the ListIDPOptions based on completed values
+func (o *ListIDPOptions) Validate() (err error) {
+	if len(o.catalogList) == 0 {
+		return fmt.Errorf("no Iterative-Dev Packs found")
+	}
+
+	return err
+}
+
+// Run contains the logic for the command associated with ListIDPOptions
+func (o *ListIDPOptions) Run() (err error) {
+	w := tabwriter.NewWriter(os.Stdout, 5, 2, 3, ' ', tabwriter.TabIndent)
+	fmt.Fprintln(w, "NAME", "\t", "LANGUAGE", "\t", "FRAMEWORK")
+	for _, idp := range o.catalogList {
+		idpName := idp.Name
+		idpFramework := idp.Framework
+		idpLanguage := idp.Language
+		fmt.Fprintln(w, idpName, "\t", idpLanguage, "\t", idpFramework)
+	}
+	w.Flush()
+	return
+}
+
+// NewCmdCatalogListIDPs implements the kdo catalog list idps command
+func NewCmdCatalogListIDPs(name, fullName string) *cobra.Command {
+	o := NewListIDPOptions()
+
+	return &cobra.Command{
+		Use:     name,
+		Short:   "List all IDPs available.",
+		Long:    "List all available Iterative-Dev Packs.",
+		Example: fmt.Sprintf(idpsExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(o, cmd, args)
+		},
+	}
+
+}

--- a/pkg/kdo/cli/catalog/list/list.go
+++ b/pkg/kdo/cli/catalog/list/list.go
@@ -1,0 +1,29 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo-fork/pkg/kdo/util"
+	"github.com/spf13/cobra"
+)
+
+// RecommendedCommandName is the recommended command name
+const RecommendedCommandName = "list"
+
+// NewCmdCatalogList implements the kdo catalog list command
+func NewCmdCatalogList(name, fullName string) *cobra.Command {
+	idp := NewCmdCatalogListIDPs(idpRecommendedCommandName, util.GetFullName(fullName, idpRecommendedCommandName))
+
+	catalogListCmd := &cobra.Command{
+		Use:     name,
+		Short:   "List all available Iterative-Dev packs.",
+		Long:    "List all available Iterative-Dev packs from GitHub",
+		Example: fmt.Sprintf("%s\n\n", idp.Example),
+	}
+
+	catalogListCmd.AddCommand(
+		idp,
+	)
+
+	return catalogListCmd
+}

--- a/pkg/kdo/cli/catalog/search/idp.go
+++ b/pkg/kdo/cli/catalog/search/idp.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo-fork/pkg/catalog"
+	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
+	"github.com/redhat-developer/odo-fork/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+const idpRecommendedCommandName = "idp"
+
+var idpExample = `  # Search for an iterative-dev pack
+  %[1]s python`
+
+// SearchIDPOptions encapsulates the options for the kdo catalog search idp command
+type SearchIDPOptions struct {
+	searchTerm string
+	idps       []string
+	// generic context options common to all commands
+	*genericclioptions.Context
+}
+
+// NewSearchIDPOptions creates a new SearchIDPOptions instance
+func NewSearchIDPOptions() *SearchIDPOptions {
+	return &SearchIDPOptions{}
+}
+
+// Complete completes SearchIDPOptions after they've been created
+func (o *SearchIDPOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	o.searchTerm = args[0]
+	o.idps, err = catalog.Search(o.searchTerm)
+	return err
+}
+
+// Validate validates the SearchIDPOptions based on completed values
+func (o *SearchIDPOptions) Validate() (err error) {
+	if len(o.idps) == 0 {
+		return fmt.Errorf("no iterative-dev pack matched the query: %s", o.searchTerm)
+	}
+
+	return
+}
+
+// Run contains the logic for the command associated with SearchIDPOptions
+func (o *SearchIDPOptions) Run() (err error) {
+	log.Infof("The following Iterative-Dev Packs were found:")
+	for _, idp := range o.idps {
+		fmt.Printf("- %v\n", idp)
+	}
+	return
+}
+
+// NewCmdCatalogSearchIDP implements the kdo catalog search idp command
+func NewCmdCatalogSearchIDP(name, fullName string) *cobra.Command {
+	o := NewSearchIDPOptions()
+	return &cobra.Command{
+		Use:   name,
+		Short: "Search Iterative-Dev Pack in catalog",
+		Long: `Search Iterative-Dev Pack in catalog.
+
+This searches for a partial match for the given search term in all the available
+Iterative-Dev Packs.
+`,
+		Args:    cobra.ExactArgs(1),
+		Example: fmt.Sprintf(idpExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(o, cmd, args)
+		},
+	}
+}

--- a/pkg/kdo/cli/catalog/search/search.go
+++ b/pkg/kdo/cli/catalog/search/search.go
@@ -1,0 +1,29 @@
+package search
+
+import (
+	"fmt"
+
+	"github.com/redhat-developer/odo-fork/pkg/kdo/util"
+	"github.com/spf13/cobra"
+)
+
+// RecommendedCommandName is the recommended command name
+const RecommendedCommandName = "search"
+
+// NewCmdCatalogSearch implements the kdo catalog search command
+func NewCmdCatalogSearch(name, fullName string) *cobra.Command {
+	component := NewCmdCatalogSearchIDP(idpRecommendedCommandName, util.GetFullName(fullName, idpRecommendedCommandName))
+	catalogSearchCmd := &cobra.Command{
+		Use:   name,
+		Short: "Search available Iterative-Dev Packs",
+		Long: `Search available  Iterative-Dev Packs..
+
+This searches for a partial match for the given search term in all the available
+Iterative-Dev Packs.
+`,
+		Example: fmt.Sprintf("%s\n", component.Example),
+	}
+	catalogSearchCmd.AddCommand(component)
+
+	return catalogSearchCmd
+}

--- a/pkg/kdo/cli/cli.go
+++ b/pkg/kdo/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/odo-fork/pkg/common"
+	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/catalog"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/component"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/config"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/cli/version"
@@ -73,6 +74,7 @@ func NewCmdKdo(name, fullName string) *cobra.Command {
 		Long:    kdoLong,
 		Example: fmt.Sprintf(kdoExample, fullName),
 	}
+
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
@@ -98,6 +100,7 @@ func NewCmdKdo(name, fullName string) *cobra.Command {
 	cobra.AddTemplateFunc("CapitalizeFlagDescriptions", kdoutil.CapitalizeFlagDescriptions)
 
 	rootCmd.AddCommand(
+		catalog.NewCmdCatalog(catalog.RecommendedCommandName, kdoutil.GetFullName(fullName, catalog.RecommendedCommandName)),
 		common.CmdPrintKdo,
 		component.NewCmdCreate(component.CreateRecommendedCommandName, kdoutil.GetFullName(fullName, component.CreateRecommendedCommandName)),
 		version.NewCmdVersion(version.RecommendedCommandName, kdoutil.GetFullName(fullName, version.RecommendedCommandName)),

--- a/pkg/kdo/cli/component/ui/ui.go
+++ b/pkg/kdo/cli/component/ui/ui.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SelectComponentType lets the user to select the builder image (name only) in the prompt
-func SelectComponentType(options []catalog.CatalogImage) string {
+func SelectComponentType(options []catalog.CatalogEntry) string {
 	var componentType string
 	prompt := &survey.Select{
 		Message: "Which component type do you wish to create",
@@ -28,36 +28,13 @@ func SelectComponentType(options []catalog.CatalogImage) string {
 	return componentType
 }
 
-func getComponentTypeNameCandidates(options []catalog.CatalogImage) []string {
+func getComponentTypeNameCandidates(options []catalog.CatalogEntry) []string {
 	result := make([]string, len(options))
 	for i, option := range options {
 		result[i] = option.Name
 	}
 	sort.Strings(result)
 	return result
-}
-
-// SelectImageTag lets the user to select a specific tag for the previously selected builder image in a prompt
-func SelectImageTag(options []catalog.CatalogImage, selectedComponentType string) string {
-	var tag string
-	prompt := &survey.Select{
-		Message: fmt.Sprintf("Which version of '%s' component type do you wish to create", selectedComponentType),
-		Options: getTagCandidates(options, selectedComponentType),
-	}
-	err := survey.AskOne(prompt, &tag, survey.Required)
-	ui.HandleError(err)
-	return tag
-}
-
-func getTagCandidates(options []catalog.CatalogImage, selectedComponentType string) []string {
-	for _, option := range options {
-		if option.Name == selectedComponentType {
-			sort.Strings(option.NonHiddenTags)
-			return option.NonHiddenTags
-		}
-	}
-	glog.V(4).Infof("Selected component type %s was not part of the catalog images", selectedComponentType)
-	return []string{}
 }
 
 // SelectSourceType lets the user select a specific config.SrcType in a prompty


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What is the purpose of this change? What does it change?
This PR implements the catalog functionality for `kdo` and adds the `kdo catalog` command in. The catalog retrieves a list of Iterative-Dev packs from a GitHub repository (temporarily https://github.com/johnmcollier/iterative-dev-packs) that can then be used for a user's component/application.