### PR TITLE
Kdo push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
-	github.com/kubernetes-incubator/service-catalog v0.2.1 // indirect
+	github.com/kubernetes-incubator/service-catalog v0.2.1
 	github.com/mattn/go-colorable v0.1.2
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
-	github.com/kubernetes-incubator/service-catalog v0.2.1
 	github.com/mattn/go-colorable v0.1.2
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -99,6 +100,7 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -112,6 +114,7 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubernetes-incubator/service-catalog v0.2.1/go.mod h1:D0CRODiXUJs6VCZDB15TmCkesbuizkac9fYEiTA78BA=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -1,0 +1,121 @@
+package application
+
+import (
+	// "github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
+	"github.com/redhat-developer/odo-fork/pkg/kclient"
+	"github.com/redhat-developer/odo-fork/pkg/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	appPrefixMaxLen   = 12
+	appNameMaxRetries = 3
+	appAPIVersion     = "odo.openshift.io/v1alpha1"
+	appKind           = "app"
+	appList           = "List"
+)
+
+// List all applications in current project
+func List(client *kclient.Client) ([]string, error) {
+	return ListInProject(client)
+}
+
+// ListInProject lists all applications in given project by Querying the cluster
+func ListInProject(client *kclient.Client) ([]string, error) {
+
+	var appNames []string
+
+	// Get all DeploymentConfigs with the "app" label
+	deploymentConfigAppNames, err := client.GetDeploymentLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list applications from deployment config")
+	}
+
+	appNames = append(appNames, deploymentConfigAppNames...)
+
+	// Removed following ODO code, need to evaluate whether KDO needs an equivalent lookup
+	// // Get all ServiceInstances with the "app" label
+	// // Okay, so there is an edge-case here.. if Service Catalog is *not* enabled in the cluster, we shouldn't error out..
+	// // however, we should at least warn the user.
+	// serviceInstanceAppNames, err := client.GetServiceInstanceLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
+	// if err != nil {
+	// 	glog.V(4).Infof("Unable to list Service Catalog instances: %s", err)
+	// 	log.Warning("Unable to access Service Catalog instances, may not be enabled on cluster")
+	// } else {
+	// 	appNames = append(deploymentConfigAppNames, serviceInstanceAppNames...)
+	// }
+
+	// Filter out any names, as there could be multiple components but within the same application
+	return util.RemoveDuplicates(appNames), nil
+}
+
+// Exists checks whether the given app exist or not
+func Exists(app string, client *kclient.Client) (bool, error) {
+
+	appList, err := List(client)
+	if err != nil {
+		return false, err
+	}
+	for _, appName := range appList {
+		if appName == app {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// TODO-KDO: Add when implementing application commands
+// // Delete deletes the given application
+// func Delete(client *kclient.Client, name string) error {
+// 	glog.V(4).Infof("Deleting application %s", name)
+
+// 	labels := applabels.GetLabels(name, false)
+
+// 	// delete application from cluster
+// 	err := client.Delete(labels)
+// 	if err != nil {
+// 		return errors.Wrapf(err, "unable to delete application %s", name)
+// 	}
+
+// 	return nil
+// }
+
+// TODO-KDO: Add when implementing application commands
+// // GetMachineReadableFormat returns resource information in machine readable format
+// func GetMachineReadableFormat(client *kclient.Client, appName string, projectName string) App {
+// 	componentList, _ := component.List(client, appName)
+// 	var compList []string
+// 	for _, comp := range componentList.Items {
+// 		compList = append(compList, comp.Name)
+// 	}
+// 	appDef := App{
+// 		TypeMeta: metav1.TypeMeta{
+// 			Kind:       appKind,
+// 			APIVersion: appAPIVersion,
+// 		},
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      appName,
+// 			Namespace: projectName,
+// 		},
+// 		Spec: AppSpec{
+// 			Components: compList,
+// 		},
+// 	}
+// 	return appDef
+// }
+
+// GetMachineReadableFormatForList returns application list in machine readable format
+func GetMachineReadableFormatForList(apps []App) AppList {
+	return AppList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       appList,
+			APIVersion: appAPIVersion,
+		},
+		ListMeta: metav1.ListMeta{},
+		Items:    apps,
+	}
+}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -13,7 +13,7 @@ import (
 const (
 	appPrefixMaxLen   = 12
 	appNameMaxRetries = 3
-	appAPIVersion     = "odo.openshift.io/v1alpha1"
+	appAPIVersion     = "apps.kdo.io/v1alpha1"
 	appKind           = "app"
 	appList           = "List"
 )

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	// "github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
@@ -29,31 +28,19 @@ func ListInProject(client *kclient.Client) ([]string, error) {
 
 	var appNames []string
 
-	// Get all DeploymentConfigs with the "app" label
-	deploymentConfigAppNames, err := client.GetDeploymentLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
+	// Get all Deployments with the "app" label
+	deploymentAppNames, err := client.GetDeploymentLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list applications from deployment config")
+		return nil, errors.Wrap(err, "unable to list applications from deployment")
 	}
 
-	appNames = append(appNames, deploymentConfigAppNames...)
-
-	// Removed following ODO code, need to evaluate whether KDO needs an equivalent lookup
-	// // Get all ServiceInstances with the "app" label
-	// // Okay, so there is an edge-case here.. if Service Catalog is *not* enabled in the cluster, we shouldn't error out..
-	// // however, we should at least warn the user.
-	// serviceInstanceAppNames, err := client.GetServiceInstanceLabelValues(applabels.ApplicationLabel, applabels.ApplicationLabel)
-	// if err != nil {
-	// 	glog.V(4).Infof("Unable to list Service Catalog instances: %s", err)
-	// 	log.Warning("Unable to access Service Catalog instances, may not be enabled on cluster")
-	// } else {
-	// 	appNames = append(deploymentConfigAppNames, serviceInstanceAppNames...)
-	// }
+	appNames = append(appNames, deploymentAppNames...)
 
 	// Filter out any names, as there could be multiple components but within the same application
 	return util.RemoveDuplicates(appNames), nil
 }
 
-// Exists checks whether the given app exist or not
+// Exists checks whether the given app exists or not
 func Exists(app string, client *kclient.Client) (bool, error) {
 
 	appList, err := List(client)
@@ -67,46 +54,6 @@ func Exists(app string, client *kclient.Client) (bool, error) {
 	}
 	return false, nil
 }
-
-// TODO-KDO: Add when implementing application commands
-// // Delete deletes the given application
-// func Delete(client *kclient.Client, name string) error {
-// 	glog.V(4).Infof("Deleting application %s", name)
-
-// 	labels := applabels.GetLabels(name, false)
-
-// 	// delete application from cluster
-// 	err := client.Delete(labels)
-// 	if err != nil {
-// 		return errors.Wrapf(err, "unable to delete application %s", name)
-// 	}
-
-// 	return nil
-// }
-
-// TODO-KDO: Add when implementing application commands
-// // GetMachineReadableFormat returns resource information in machine readable format
-// func GetMachineReadableFormat(client *kclient.Client, appName string, projectName string) App {
-// 	componentList, _ := component.List(client, appName)
-// 	var compList []string
-// 	for _, comp := range componentList.Items {
-// 		compList = append(compList, comp.Name)
-// 	}
-// 	appDef := App{
-// 		TypeMeta: metav1.TypeMeta{
-// 			Kind:       appKind,
-// 			APIVersion: appAPIVersion,
-// 		},
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Name:      appName,
-// 			Namespace: projectName,
-// 		},
-// 		Spec: AppSpec{
-// 			Components: compList,
-// 		},
-// 	}
-// 	return appDef
-// }
 
 // GetMachineReadableFormatForList returns application list in machine readable format
 func GetMachineReadableFormatForList(apps []App) AppList {

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -4,128 +4,121 @@ import (
 	"reflect"
 	"testing"
 
-	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
-	"github.com/redhat-developer/odo-fork/pkg/component"
-	componentlabels "github.com/redhat-developer/odo-fork/pkg/component/labels"
-	"github.com/redhat-developer/odo-fork/pkg/kclient"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	ktesting "k8s.io/client-go/testing"
 )
 
-func TestGetMachineReadableFormat(t *testing.T) {
-	type args struct {
-		// client      *kclient.Client
-		appName     string
-		projectName string
-		active      bool
-	}
-	tests := []struct {
-		name string
-		args args
-		want App
-	}{
-		{
+// TODO-KDO: Enable when GetMachineReadableFormat is implemented in the application package
+// func TestGetMachineReadableFormat(t *testing.T) {
+// 	type args struct {
+// 		// client      *kclient.Client
+// 		appName     string
+// 		projectName string
+// 		active      bool
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want App
+// 	}{
+// 		{
 
-			name: "Test Case: machine readable output for application",
-			args: args{
-				appName:     "myapp",
-				projectName: "myproject",
-				active:      true,
-			},
-			want: App{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       appKind,
-					APIVersion: appAPIVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "myapp",
-					Namespace: "myproject",
-				},
-				Spec: AppSpec{
-					Components: []string{"frontend"},
-				},
-			},
-		},
-	}
+// 			name: "Test Case: machine readable output for application",
+// 			args: args{
+// 				appName:     "myapp",
+// 				projectName: "myproject",
+// 				active:      true,
+// 			},
+// 			want: App{
+// 				TypeMeta: metav1.TypeMeta{
+// 					Kind:       appKind,
+// 					APIVersion: appAPIVersion,
+// 				},
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "myapp",
+// 					Namespace: "myproject",
+// 				},
+// 				Spec: AppSpec{
+// 					Components: []string{"frontend"},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	dcList := appsv1.DeploymentList{
-		Items: []appsv1.Deployment{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "frontend-myapp",
-					Namespace: "myproject",
-					Labels: map[string]string{
-						applabels.ApplicationLabel:         "myapp",
-						componentlabels.ComponentLabel:     "frontend",
-						componentlabels.ComponentTypeLabel: "nodejs",
-					},
-					Annotations: map[string]string{
-						component.ComponentSourceTypeAnnotation: "local",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "dummyContainer",
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backend-app",
-					Namespace: "myproject",
-					Labels: map[string]string{
-						applabels.ApplicationLabel:         "app",
-						componentlabels.ComponentLabel:     "backend",
-						componentlabels.ComponentTypeLabel: "java",
-					},
-					Annotations: map[string]string{
-						component.ComponentSourceTypeAnnotation: "local",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "dummyContainer",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+// 	dcList := appsv1.DeploymentList{
+// 		Items: []appsv1.Deployment{
+// 			{
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "frontend-myapp",
+// 					Namespace: "myproject",
+// 					Labels: map[string]string{
+// 						applabels.ApplicationLabel:         "myapp",
+// 						componentlabels.ComponentLabel:     "frontend",
+// 						componentlabels.ComponentTypeLabel: "nodejs",
+// 					},
+// 					Annotations: map[string]string{
+// 						component.ComponentSourceTypeAnnotation: "local",
+// 					},
+// 				},
+// 				Spec: appsv1.DeploymentSpec{
+// 					Template: corev1.PodTemplateSpec{
+// 						Spec: corev1.PodSpec{
+// 							Containers: []corev1.Container{
+// 								{
+// 									Name: "dummyContainer",
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			{
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "backend-app",
+// 					Namespace: "myproject",
+// 					Labels: map[string]string{
+// 						applabels.ApplicationLabel:         "app",
+// 						componentlabels.ComponentLabel:     "backend",
+// 						componentlabels.ComponentTypeLabel: "java",
+// 					},
+// 					Annotations: map[string]string{
+// 						component.ComponentSourceTypeAnnotation: "local",
+// 					},
+// 				},
+// 				Spec: appsv1.DeploymentSpec{
+// 					Template: corev1.PodTemplateSpec{
+// 						Spec: corev1.PodSpec{
+// 							Containers: []corev1.Container{
+// 								{
+// 									Name: "dummyContainer",
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Fake the client with the appropriate arguments
-			client, fakeClientSet := kclient.FakeNew()
-			//fake the dcs
-			fakeClientSet.Kubernetes.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
-				return true, &dcList, nil
-			})
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			// Fake the client with the appropriate arguments
+// 			client, fakeClientSet := kclient.FakeNew()
+// 			//fake the dcs
+// 			fakeClientSet.Kubernetes.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+// 				return true, &dcList, nil
+// 			})
 
-			for i := range dcList.Items {
-				fakeClientSet.Kubernetes.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
-					return true, &dcList.Items[i], nil
-				})
-			}
-			if got := GetMachineReadableFormat(client, tt.args.appName, tt.args.projectName); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetMachineReadableFormat() = %v,\n want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 			for i := range dcList.Items {
+// 				fakeClientSet.Kubernetes.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+// 					return true, &dcList.Items[i], nil
+// 				})
+// 			}
+// 			if got := GetMachineReadableFormat(client, tt.args.appName, tt.args.projectName); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("GetMachineReadableFormat() = %v,\n want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestGetMachineReadableFormatForList(t *testing.T) {
 	type args struct {

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,0 +1,194 @@
+package application
+
+import (
+	"reflect"
+	"testing"
+
+	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
+	"github.com/redhat-developer/odo-fork/pkg/component"
+	componentlabels "github.com/redhat-developer/odo-fork/pkg/component/labels"
+	"github.com/redhat-developer/odo-fork/pkg/kclient"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestGetMachineReadableFormat(t *testing.T) {
+	type args struct {
+		// client      *kclient.Client
+		appName     string
+		projectName string
+		active      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want App
+	}{
+		{
+
+			name: "Test Case: machine readable output for application",
+			args: args{
+				appName:     "myapp",
+				projectName: "myproject",
+				active:      true,
+			},
+			want: App{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       appKind,
+					APIVersion: appAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myapp",
+					Namespace: "myproject",
+				},
+				Spec: AppSpec{
+					Components: []string{"frontend"},
+				},
+			},
+		},
+	}
+
+	dcList := appsv1.DeploymentList{
+		Items: []appsv1.Deployment{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "frontend-myapp",
+					Namespace: "myproject",
+					Labels: map[string]string{
+						applabels.ApplicationLabel:         "myapp",
+						componentlabels.ComponentLabel:     "frontend",
+						componentlabels.ComponentTypeLabel: "nodejs",
+					},
+					Annotations: map[string]string{
+						component.ComponentSourceTypeAnnotation: "local",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "dummyContainer",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backend-app",
+					Namespace: "myproject",
+					Labels: map[string]string{
+						applabels.ApplicationLabel:         "app",
+						componentlabels.ComponentLabel:     "backend",
+						componentlabels.ComponentTypeLabel: "java",
+					},
+					Annotations: map[string]string{
+						component.ComponentSourceTypeAnnotation: "local",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "dummyContainer",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fake the client with the appropriate arguments
+			client, fakeClientSet := kclient.FakeNew()
+			//fake the dcs
+			fakeClientSet.Kubernetes.PrependReactor("list", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, &dcList, nil
+			})
+
+			for i := range dcList.Items {
+				fakeClientSet.Kubernetes.PrependReactor("get", "deploymentconfigs", func(action ktesting.Action) (bool, runtime.Object, error) {
+					return true, &dcList.Items[i], nil
+				})
+			}
+			if got := GetMachineReadableFormat(client, tt.args.appName, tt.args.projectName); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetMachineReadableFormat() = %v,\n want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMachineReadableFormatForList(t *testing.T) {
+	type args struct {
+		apps []App
+	}
+	tests := []struct {
+		name string
+		args args
+		want AppList
+	}{
+		{
+			name: "Test Case: Machine Readable for Application List",
+			args: args{
+				apps: []App{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       appKind,
+							APIVersion: appAPIVersion,
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myapp",
+						},
+						Spec: AppSpec{
+							Components: []string{"frontend"},
+						},
+						Status: AppStatus{
+							Active: true,
+						},
+					},
+				},
+			},
+			want: AppList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       appList,
+					APIVersion: appAPIVersion,
+				},
+				ListMeta: metav1.ListMeta{},
+				Items: []App{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       appKind,
+							APIVersion: appAPIVersion,
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "myapp",
+						},
+						Spec: AppSpec{
+							Components: []string{"frontend"},
+						},
+						Status: AppStatus{
+							Active: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetMachineReadableFormatForList(tt.args.apps); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetMachineReadableFormatForList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/application/labels/labels.go
+++ b/pkg/application/labels/labels.go
@@ -1,0 +1,30 @@
+package labels
+
+// ApplicationLabel is label key that is used to group all object that belong to one application
+// It should be save to use just this label to filter application
+const ApplicationLabel = "app.kubernetes.io/name"
+
+// AdditionalApplicationLabels additional labels that are applied to all objects belonging to one application
+// Those labels are not used for filtering or grouping, they are used just when creating and they are mend to be used by other tools
+var AdditionalApplicationLabels = []string{
+	// OpenShift Web console uses this label for grouping
+	"app",
+}
+
+// GetLabels return labels that identifies given application
+// additional labels are used only when creating object
+// if you are creating something use additional=true
+// if you need labels to filter component than use additional=false
+func GetLabels(application string, additional bool) map[string]string {
+	labels := map[string]string{
+		ApplicationLabel: application,
+	}
+
+	if additional {
+		for _, additionalLabel := range AdditionalApplicationLabels {
+			labels[additionalLabel] = application
+		}
+	}
+
+	return labels
+}

--- a/pkg/application/labels/labels_test.go
+++ b/pkg/application/labels/labels_test.go
@@ -1,0 +1,48 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything",
+			args: args{
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				ApplicationLabel: "applicationame",
+			},
+		},
+		{
+			name: "everything with additional",
+			args: args{
+
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				ApplicationLabel:               "applicationame",
+				AdditionalApplicationLabels[0]: "applicationame",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -1,0 +1,30 @@
+package application
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Application
+type App struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              AppSpec   `json:"spec,omitempty"`
+	Status            AppStatus `json:"status,omitempty"`
+}
+
+// AppSpec is list of components present in given application
+type AppSpec struct {
+	Components []string `json:"components,omitempty"`
+}
+
+// AppList is a list of applications
+type AppList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []App `json:"items"`
+}
+
+// AppStatus shows the application is active or not
+type AppStatus struct {
+	Active bool `json:"active"`
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -244,14 +244,14 @@ func CreateFromPath(client *kclient.Client, params kclient.CreateArgs) error {
 	annotations[ComponentSourceTypeAnnotation] = string(params.SourceType)
 
 	// Namespace the component
-	namespacedOpenShiftObject, err := util.NamespaceKubernetesObject(params.Name, params.ApplicationName)
+	namespacedKubernetesObject, err := util.NamespaceKubernetesObject(params.Name, params.ApplicationName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create namespaced name")
 	}
 
 	// Create CommonObjectMeta to be passed in
 	commonObjectMeta := metav1.ObjectMeta{
-		Name:        namespacedOpenShiftObject,
+		Name:        namespacedKubernetesObject,
 		Labels:      labels,
 		Annotations: annotations,
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -685,18 +685,12 @@ func PushLocal(client *kclient.Client, componentName string, applicationName str
 		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
 	}
 
-	// Get S2I Source/Binary Path from Pod Env variables created at the time of component create
-	// s2iSrcPath := getEnvFromPodEnvs(kclient.EnvS2ISrcOrBinPath, pod.Spec.Containers[0].Env)
-	// if s2iSrcPath == "" {
-	// 	s2iSrcPath = kclient.DefaultS2ISrcOrBinPath
-	// }
-	// targetPath := fmt.Sprintf("%s/src", s2iSrcPath)
-
 	// If there are files identified as deleted, propagate them to the component pod
 	if len(delFiles) > 0 {
 		glog.V(4).Infof("propogating deletion of files %s to pod", strings.Join(delFiles, " "))
 		/*
-			Delete files observed by watch to have been deleted from each of s2i directories like:
+			Delete files observed by watch from each of the directories in the specified pod. The directories are an array because the source can
+			be copied to more than one directory depending on the build controller. Eg. For s2i the following directories can contain the source:
 				deployment dir: In interpreted runtimes like python, source is copied over to deployment dir so delete needs to happen here as well
 				destination dir: This is the directory where s2i expects source to be copied for it be built and deployed
 				working dir: Directory where, sources are copied over from deployment dir from where the s2i builds and deploys source.

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1,7 +1,9 @@
 package component
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,7 @@ import (
 
 	// applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
 	"github.com/redhat-developer/odo-fork/pkg/catalog"
+	componentlabels "github.com/redhat-developer/odo-fork/pkg/component/labels"
 
 	"github.com/redhat-developer/odo-fork/pkg/config"
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
@@ -22,6 +25,9 @@ import (
 	// "github.com/redhat-developer/odo-fork/pkg/storage"
 	// urlpkg "github.com/redhat-developer/odo-fork/pkg/url"
 	"github.com/redhat-developer/odo-fork/pkg/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // componentSourceURLAnnotation is an source url from which component was build
@@ -31,6 +37,13 @@ const ComponentSourceTypeAnnotation = "app.kubernetes.io/component-source-type"
 const componentRandomNamePartsMaxLen = 12
 const componentNameMaxRetries = 3
 const componentNameMaxLen = -1
+
+// Target defines a target image environment which can be based on an IDP or s2i image
+type Target struct {
+	// Path is the location to copy the source
+	SrcPath string
+	Paths   []string
+}
 
 // GetComponentDir returns source repo name
 // Parameters:
@@ -209,64 +222,64 @@ func validateSourceType(sourceType string) bool {
 // 	return secretNames, nil
 // }
 
-// // CreateFromPath create new component with source or binary from the given local path
-// // sourceType indicates the source type of the component and can be either local or binary
-// // envVars is the array containing the environment variables
-// func CreateFromPath(client *kclient.Client, params kclient.CreateArgs) error {
-// 	labels := componentlabels.GetLabels(params.Name, params.ApplicationName, true)
+// CreateFromPath create new component with source or binary from the given local path
+// sourceType indicates the source type of the component and can be either local or binary
+// envVars is the array containing the environment variables
+func CreateFromPath(client *kclient.Client, params kclient.CreateArgs) error {
+	labels := componentlabels.GetLabels(params.Name, params.ApplicationName, true)
 
-// 	// Parse componentImageType before adding to labels
-// 	_, imageName, imageTag, _, err := kclient.ParseImageName(params.ImageName)
-// 	if err != nil {
-// 		return errors.Wrap(err, "unable to parse image name")
-// 	}
+	// Parse componentImageType before adding to labels
+	_, imageName, imageTag, _, err := kclient.ParseImageName(params.ImageName)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse image name")
+	}
 
-// 	// save component type as label
-// 	labels[componentlabels.ComponentTypeLabel] = imageName
-// 	labels[componentlabels.ComponentTypeVersion] = imageTag
+	// save component type as label
+	labels[componentlabels.ComponentTypeLabel] = imageName
+	labels[componentlabels.ComponentTypeVersion] = imageTag
 
-// 	// save source path as annotation
-// 	sourceURL := util.GenFileURL(params.SourcePath)
-// 	annotations := map[string]string{componentSourceURLAnnotation: sourceURL}
-// 	annotations[ComponentSourceTypeAnnotation] = string(params.SourceType)
+	// save source path as annotation
+	sourceURL := util.GenFileURL(params.SourcePath)
+	annotations := map[string]string{componentSourceURLAnnotation: sourceURL}
+	annotations[ComponentSourceTypeAnnotation] = string(params.SourceType)
 
-// 	// Namespace the component
-// 	namespacedOpenShiftObject, err := util.NamespaceOpenShiftObject(params.Name, params.ApplicationName)
-// 	if err != nil {
-// 		return errors.Wrapf(err, "unable to create namespaced name")
-// 	}
+	// Namespace the component
+	namespacedOpenShiftObject, err := util.NamespaceKubernetesObject(params.Name, params.ApplicationName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create namespaced name")
+	}
 
-// 	// Create CommonObjectMeta to be passed in
-// 	commonObjectMeta := metav1.ObjectMeta{
-// 		Name:        namespacedOpenShiftObject,
-// 		Labels:      labels,
-// 		Annotations: annotations,
-// 	}
+	// Create CommonObjectMeta to be passed in
+	commonObjectMeta := metav1.ObjectMeta{
+		Name:        namespacedOpenShiftObject,
+		Labels:      labels,
+		Annotations: annotations,
+	}
 
-// 	// Bootstrap the deployment with SupervisorD
-// 	err = client.BootstrapSupervisoredS2I(params, commonObjectMeta)
-// 	if err != nil {
-// 		return err
-// 	}
+	// Create component resources
+	err = client.CreateComponentResources(params, commonObjectMeta)
+	if err != nil {
+		return err
+	}
 
-// 	if params.Wait {
-// 		// if wait flag is present then extract the podselector
-// 		// use the podselector for calling WaitAndGetPod
-// 		selectorLabels, err := util.NamespaceOpenShiftObject(labels[componentlabels.ComponentLabel], labels["app"])
-// 		if err != nil {
-// 			return err
-// 		}
+	if params.Wait {
+		// if wait flag is present then extract the podselector
+		// use the podselector for calling WaitAndGetPod
+		selectorLabels, err := util.NamespaceKubernetesObject(labels[componentlabels.ComponentLabel], labels["app"])
+		if err != nil {
+			return err
+		}
 
-// 		podSelector := fmt.Sprintf("deploymentconfig=%s", selectorLabels)
-// 		_, err = client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	}
+		podSelector := fmt.Sprintf("deploymentconfig=%s", selectorLabels)
+		_, err = client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
-// 	return nil
-// }
+	return nil
+}
 
 // // Delete whole component
 // func Delete(client *kclient.Client, componentName string, applicationName string) error {
@@ -335,97 +348,100 @@ func validateSourceType(sourceType string) bool {
 // 	return retVal
 // }
 
-// // CreateComponent creates component as per the passed component settings
-// //	Parameters:
-// //		client: kclient instance
-// //		componentConfig: the component configuration that holds all details of component
-// //		context: the component context indicating the location of component config and hence its source as well
-// //		stdout: io.Writer instance to write output to
-// //	Returns:
-// //		err: errors if any
-// func CreateComponent(client *kclient.Client, componentConfig config.LocalConfigInfo, context string, stdout io.Writer) (err error) {
+// CreateComponent creates component as per the passed component settings
+//	Parameters:
+//		client: kclient instance
+//		componentConfig: the component configuration that holds all details of component
+//		context: the component context indicating the location of component config and hence its source as well
+//		stdout: io.Writer instance to write output to
+//	Returns:
+//		err: errors if any
+func CreateComponent(client *kclient.Client, componentConfig config.LocalConfigInfo, context string, stdout io.Writer) (err error) {
 
-// 	cmpName := componentConfig.GetName()
-// 	cmpType := componentConfig.GetType()
-// 	cmpSrcType := componentConfig.GetSourceType()
-// 	cmpPorts := componentConfig.GetPorts()
-// 	cmpSrcRef := componentConfig.GetRef()
-// 	appName := componentConfig.GetApplication()
-// 	envVarsList := componentConfig.GetEnvVars()
+	cmpName := componentConfig.GetName()
+	cmpType := componentConfig.GetType()
+	cmpSrcType := componentConfig.GetSourceType()
+	cmpPorts := componentConfig.GetPorts()
+	// cmpSrcRef := componentConfig.GetRef()
+	appName := componentConfig.GetApplication()
+	envVarsList := componentConfig.GetEnvVars()
 
-// 	// create and get the storage to be created/mounted during the component creation
-// 	storageList := getStorageFromConfig(&componentConfig)
-// 	storageToBeMounted, _, err := storage.Push(client, storageList, componentConfig.GetName(), componentConfig.GetApplication(), false)
-// 	if err != nil {
-// 		return err
-// 	}
+	// // create and get the storage to be created/mounted during the component creation
+	// storageList := getStorageFromConfig(&componentConfig)
+	// storageToBeMounted, _, err := storage.Push(client, storageList, componentConfig.GetName(), componentConfig.GetApplication(), false)
+	// if err != nil {
+	// 	return err
+	// }
+	// TODO-KDO: remove following line and implement storage handling properly for KDO
+	storageToBeMounted := make(map[string]*corev1.PersistentVolumeClaim)
 
-// 	log.Successf("Initializing component")
-// 	createArgs := kclient.CreateArgs{
-// 		Name:               cmpName,
-// 		ImageName:          cmpType,
-// 		ApplicationName:    appName,
-// 		EnvVars:            envVarsList.ToStringSlice(),
-// 		StorageToBeMounted: storageToBeMounted,
-// 	}
-// 	createArgs.SourceType = cmpSrcType
-// 	createArgs.SourcePath = componentConfig.GetSourceLocation()
+	log.Successf("Initializing component")
+	createArgs := kclient.CreateArgs{
+		Name:               cmpName,
+		ImageName:          cmpType,
+		ApplicationName:    appName,
+		EnvVars:            envVarsList.ToStringSlice(),
+		StorageToBeMounted: storageToBeMounted,
+	}
+	createArgs.SourceType = cmpSrcType
+	createArgs.SourcePath = componentConfig.GetSourceLocation()
 
-// 	if len(cmpPorts) > 0 {
-// 		createArgs.Ports = cmpPorts
-// 	}
+	if len(cmpPorts) > 0 {
+		createArgs.Ports = cmpPorts
+	}
 
-// 	createArgs.Resources, err = kclient.GetResourceRequirementsFromCmpSettings(componentConfig)
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to create component")
-// 	}
+	createArgs.Resources, err = kclient.GetResourceRequirementsFromCmpSettings(componentConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to create component")
+	}
 
-// 	switch cmpSrcType {
-// 	case config.GIT:
-// 		// Use Git
-// 		if cmpSrcRef != "" {
-// 			createArgs.SourceRef = cmpSrcRef
-// 		}
+	switch cmpSrcType {
+	// TODO-KDO: Decide whether to implement create component from git, possibly use tekton pipeline for this scenario
+	// case config.GIT:
+	// 	// Use Git
+	// 	if cmpSrcRef != "" {
+	// 		createArgs.SourceRef = cmpSrcRef
+	// 	}
 
-// 		createArgs.Wait = true
-// 		createArgs.StdOut = stdout
+	// 	createArgs.Wait = true
+	// 	createArgs.StdOut = stdout
 
-// 		if err = CreateFromGit(
-// 			client,
-// 			createArgs,
-// 		); err != nil {
-// 			return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
-// 		}
-// 	case config.LOCAL:
-// 		fileInfo, err := os.Stat(createArgs.SourcePath)
-// 		if err != nil {
-// 			return errors.Wrapf(err, "failed to get info of path %+v of component %+v", createArgs.SourcePath, createArgs)
-// 		}
-// 		if !fileInfo.IsDir() {
-// 			return fmt.Errorf("component creation with args %+v as path needs to be a directory", createArgs)
-// 		}
-// 		// Create
-// 		if err = CreateFromPath(client, createArgs); err != nil {
-// 			return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
-// 		}
-// 	case config.BINARY:
-// 		if err = CreateFromPath(client, createArgs); err != nil {
-// 			return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
-// 		}
-// 	default:
-// 		// If the user does not provide anything (local, git or binary), use the current absolute path and deploy it
-// 		createArgs.SourceType = config.LOCAL
-// 		dir, err := os.Getwd()
-// 		if err != nil {
-// 			return errors.Wrap(err, "failed to create component with current directory as source for the component")
-// 		}
-// 		createArgs.SourcePath = dir
-// 		if err = CreateFromPath(client, createArgs); err != nil {
-// 			return errors.Wrapf(err, "")
-// 		}
-// 	}
-// 	return
-// }
+	// 	if err = CreateFromGit(
+	// 		client,
+	// 		createArgs,
+	// 	); err != nil {
+	// 		return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
+	// 	}
+	case config.LOCAL:
+		fileInfo, err := os.Stat(createArgs.SourcePath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get info of path %+v of component %+v", createArgs.SourcePath, createArgs)
+		}
+		if !fileInfo.IsDir() {
+			return fmt.Errorf("component creation with args %+v as path needs to be a directory", createArgs)
+		}
+		// Create
+		if err = CreateFromPath(client, createArgs); err != nil {
+			return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
+		}
+	case config.BINARY:
+		if err = CreateFromPath(client, createArgs); err != nil {
+			return errors.Wrapf(err, "failed to create component with args %+v", createArgs)
+		}
+	default:
+		// If the user does not provide anything (local, git or binary), use the current absolute path and deploy it
+		createArgs.SourceType = config.LOCAL
+		dir, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "failed to create component with current directory as source for the component")
+		}
+		createArgs.SourcePath = dir
+		if err = CreateFromPath(client, createArgs); err != nil {
+			return errors.Wrapf(err, "")
+		}
+	}
+	return
+}
 
 // CheckComponentMandatoryParams checks mandatory parammeters for component
 func CheckComponentMandatoryParams(componentSettings config.ComponentSettings) error {
@@ -627,139 +643,139 @@ func ValidateComponentCreateRequest(client *kclient.Client, componentSettings co
 // 	return nil
 // }
 
-// // PushLocal push local code to the cluster and trigger build there.
-// // During copying binary components, path represent base directory path to binary and files contains path of binary
-// // During copying local source components, path represent base directory path whereas files is empty
-// // During `odo watch`, path represent base directory path whereas files contains list of changed Files
-// // Parameters:
-// //	componentName is name of the component to update sources to
-// //	applicationName is the name of the application of which the component is a part
-// //	path is base path of the component source/binary
-// // 	files is list of changed files captured during `odo watch` as well as binary file path
-// // 	delFiles is the list of files identified as deleted
-// // 	isForcePush indicates if the sources to be updated are due to a push in which case its a full source directory push or only push of identified sources
-// // 	globExps are the glob expressions which are to be ignored during the push
-// //	show determines whether or not to show the log (passed in by po.show argument within /cmd)
-// // Returns
-// //	Error if any
-// func PushLocal(client *kclient.Client, componentName string, applicationName string, path string, out io.Writer, files []string, delFiles []string, isForcePush bool, globExps []string, show bool) error {
-// 	glog.V(4).Infof("PushLocal: componentName: %s, applicationName: %s, path: %s, files: %s, delFiles: %s, isForcePush: %+v", componentName, applicationName, path, files, delFiles, isForcePush)
+// PushLocal push local code to the cluster and trigger build there.
+// During copying binary components, path represent base directory path to binary and files contains path of binary
+// During copying local source components, path represent base directory path whereas files is empty
+// During `odo watch`, path represent base directory path whereas files contains list of changed Files
+// Parameters:
+//	componentName is name of the component to update sources to
+//	applicationName is the name of the application of which the component is a part
+//	path is base path of the component source/binary
+// 	files is list of changed files captured during `odo watch` as well as binary file path
+// 	delFiles is the list of files identified as deleted
+// 	isForcePush indicates if the sources to be updated are due to a push in which case its a full source directory push or only push of identified sources
+// 	globExps are the glob expressions which are to be ignored during the push
+//	show determines whether or not to show the log (passed in by po.show argument within /cmd)
+// Returns
+//	Error if any
+func PushLocal(client *kclient.Client, componentName string, applicationName string, path string, out io.Writer, files []string, delFiles []string, isForcePush bool, globExps []string, show bool, target Target) error {
+	glog.V(4).Infof("PushLocal: componentName: %s, applicationName: %s, path: %s, files: %s, delFiles: %s, isForcePush: %+v", componentName, applicationName, path, files, delFiles, isForcePush)
 
-// 	// Edge case: check to see that the path is NOT empty.
-// 	emptyDir, err := isEmpty(path)
-// 	if err != nil {
-// 		return errors.Wrapf(err, "Unable to check directory: %s", path)
-// 	} else if emptyDir {
-// 		return errors.New(fmt.Sprintf("Directory / file %s is empty", path))
-// 	}
+	// Edge case: check to see that the path is NOT empty.
+	emptyDir, err := isEmpty(path)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to check directory: %s", path)
+	} else if emptyDir {
+		return errors.New(fmt.Sprintf("Directory / file %s is empty", path))
+	}
 
-// 	// Find DeploymentConfig for component
-// 	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
-// 	componentSelector := util.ConvertLabelsToSelector(componentLabels)
-// 	dc, err := client.GetOneDeploymentConfigFromSelector(componentSelector)
-// 	if err != nil {
-// 		return errors.Wrap(err, "unable to get deployment for component")
-// 	}
-// 	// Find Pod for component
-// 	podSelector := fmt.Sprintf("deploymentconfig=%s", dc.Name)
+	// Find Deployment for component
+	componentLabels := componentlabels.GetLabels(componentName, applicationName, false)
+	componentSelector := util.ConvertLabelsToSelector(componentLabels)
+	dc, err := client.GetOneDeploymentFromSelector(componentSelector)
+	if err != nil {
+		return errors.Wrap(err, "unable to get deployment for component")
+	}
+	// Find Pod for component
+	podSelector := fmt.Sprintf("deployment=%s", dc.Name)
 
-// 	// Wait for Pod to be in running state otherwise we can't sync data to it.
-// 	pod, err := client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
-// 	if err != nil {
-// 		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
-// 	}
+	// Wait for Pod to be in running state otherwise we can't sync data to it.
+	pod, err := client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
+	if err != nil {
+		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
+	}
 
-// 	// Get S2I Source/Binary Path from Pod Env variables created at the time of component create
-// 	s2iSrcPath := getEnvFromPodEnvs(kclient.EnvS2ISrcOrBinPath, pod.Spec.Containers[0].Env)
-// 	if s2iSrcPath == "" {
-// 		s2iSrcPath = kclient.DefaultS2ISrcOrBinPath
-// 	}
-// 	targetPath := fmt.Sprintf("%s/src", s2iSrcPath)
+	// Get S2I Source/Binary Path from Pod Env variables created at the time of component create
+	// s2iSrcPath := getEnvFromPodEnvs(kclient.EnvS2ISrcOrBinPath, pod.Spec.Containers[0].Env)
+	// if s2iSrcPath == "" {
+	// 	s2iSrcPath = kclient.DefaultS2ISrcOrBinPath
+	// }
+	// targetPath := fmt.Sprintf("%s/src", s2iSrcPath)
 
-// 	// If there are files identified as deleted, propagate them to the component pod
-// 	if len(delFiles) > 0 {
-// 		glog.V(4).Infof("propogating deletion of files %s to pod", strings.Join(delFiles, " "))
-// 		/*
-// 			Delete files observed by watch to have been deleted from each of s2i directories like:
-// 				deployment dir: In interpreted runtimes like python, source is copied over to deployment dir so delete needs to happen here as well
-// 				destination dir: This is the directory where s2i expects source to be copied for it be built and deployed
-// 				working dir: Directory where, sources are copied over from deployment dir from where the s2i builds and deploys source.
-// 							 Deletes need to happen here as well otherwise, even if the latest source is copied over, the stale source files remain
-// 				source backup dir: Directory used for backing up source across multiple iterations of push and watch in component container
-// 								   In case of python, s2i image moves sources from destination dir to workingdir which means sources are deleted from destination dir
-// 								   So, during the subsequent watch pushing new diff to component pod, the source as a whole doesn't exist at destination dir and hence needs
-// 								   to be backed up.
-// 		*/
-// 		err := client.PropagateDeletes(pod.Name, delFiles, getS2IPaths(pod.Spec.Containers[0].Env))
-// 		if err != nil {
-// 			return errors.Wrapf(err, "unable to propagate file deletions %+v", delFiles)
-// 		}
-// 	}
+	// If there are files identified as deleted, propagate them to the component pod
+	if len(delFiles) > 0 {
+		glog.V(4).Infof("propogating deletion of files %s to pod", strings.Join(delFiles, " "))
+		/*
+			Delete files observed by watch to have been deleted from each of s2i directories like:
+				deployment dir: In interpreted runtimes like python, source is copied over to deployment dir so delete needs to happen here as well
+				destination dir: This is the directory where s2i expects source to be copied for it be built and deployed
+				working dir: Directory where, sources are copied over from deployment dir from where the s2i builds and deploys source.
+							 Deletes need to happen here as well otherwise, even if the latest source is copied over, the stale source files remain
+				source backup dir: Directory used for backing up source across multiple iterations of push and watch in component container
+								   In case of python, s2i image moves sources from destination dir to workingdir which means sources are deleted from destination dir
+								   So, during the subsequent watch pushing new diff to component pod, the source as a whole doesn't exist at destination dir and hence needs
+								   to be backed up.
+		*/
+		err := client.PropagateDeletes(pod.Name, delFiles, target.Paths)
+		if err != nil {
+			return errors.Wrapf(err, "unable to propagate file deletions %+v", delFiles)
+		}
+	}
 
-// 	// Copy the files to the pod
-// 	s := log.Spinner("Copying files to component")
-// 	defer s.End(false)
+	// Copy the files to the pod
+	s := log.Spinner("Copying files to component")
+	defer s.End(false)
 
-// 	if !isForcePush {
-// 		if len(files) == 0 && len(delFiles) == 0 {
-// 			return fmt.Errorf("pass files modifications/deletions to sync to component pod or force push")
-// 		}
-// 	}
+	if !isForcePush {
+		if len(files) == 0 && len(delFiles) == 0 {
+			return fmt.Errorf("pass files modifications/deletions to sync to component pod or force push")
+		}
+	}
 
-// 	if isForcePush || len(files) > 0 {
-// 		glog.V(4).Infof("Copying files %s to pod", strings.Join(files, " "))
-// 		err = client.CopyFile(path, pod.Name, targetPath, files, globExps)
-// 		if err != nil {
-// 			s.End(false)
-// 			return errors.Wrap(err, "unable push files to pod")
-// 		}
-// 	}
-// 	s.End(true)
+	if isForcePush || len(files) > 0 {
+		glog.V(4).Infof("Copying files %s to pod", strings.Join(files, " "))
+		err = client.CopyFile(path, pod.Name, target.SrcPath, files, globExps)
+		if err != nil {
+			s.End(false)
+			return errors.Wrap(err, "unable push files to pod")
+		}
+	}
+	s.End(true)
 
-// 	if show {
-// 		s = log.SpinnerNoSpin("Building component")
-// 	} else {
-// 		s = log.Spinner("Building component")
-// 	}
+	if show {
+		s = log.SpinnerNoSpin("Building component")
+	} else {
+		s = log.Spinner("Building component")
+	}
 
-// 	// use pipes to write output from ExecCMDInContainer in yellow  to 'out' io.Writer
-// 	pipeReader, pipeWriter := io.Pipe()
-// 	var cmdOutput string
+	// use pipes to write output from ExecCMDInContainer in yellow  to 'out' io.Writer
+	pipeReader, pipeWriter := io.Pipe()
+	var cmdOutput string
 
-// 	// This Go routine will automatically pipe the output from ExecCMDInContainer to
-// 	// our logger.
-// 	go func() {
-// 		scanner := bufio.NewScanner(pipeReader)
-// 		for scanner.Scan() {
-// 			line := scanner.Text()
+	// This Go routine will automatically pipe the output from ExecCMDInContainer to
+	// our logger.
+	go func() {
+		scanner := bufio.NewScanner(pipeReader)
+		for scanner.Scan() {
+			line := scanner.Text()
 
-// 			if log.IsDebug() || show {
-// 				_, err := fmt.Fprintln(out, line)
-// 				if err != nil {
-// 					log.Errorf("Unable to print to stdout: %v", err)
-// 				}
-// 			}
+			if log.IsDebug() || show {
+				_, err := fmt.Fprintln(out, line)
+				if err != nil {
+					log.Errorf("Unable to print to stdout: %v", err)
+				}
+			}
 
-// 			cmdOutput += fmt.Sprintln(line)
-// 		}
-// 	}()
+			cmdOutput += fmt.Sprintln(line)
+		}
+	}()
 
-// 	err = client.ExecCMDInContainer(pod.Name,
-// 		// We will use the assemble-and-restart script located within the supervisord container we've created
-// 		[]string{"/var/lib/supervisord/bin/assemble-and-restart"},
-// 		pipeWriter, pipeWriter, nil, false)
+	err = client.ExecCMDInContainer(pod.Name,
+		// We will use the assemble-and-restart script located within the supervisord container we've created
+		[]string{"/var/lib/supervisord/bin/assemble-and-restart"},
+		pipeWriter, pipeWriter, nil, false)
 
-// 	if err != nil {
-// 		// If we fail, log the output
-// 		log.Errorf("Unable to build files\n%v", cmdOutput)
-// 		s.End(false)
-// 		return errors.Wrap(err, "unable to execute assemble script")
-// 	}
+	if err != nil {
+		// If we fail, log the output
+		log.Errorf("Unable to build files\n%v", cmdOutput)
+		s.End(false)
+		return errors.Wrap(err, "unable to execute assemble script")
+	}
 
-// 	s.End(true)
+	s.End(true)
 
-// 	return nil
-// }
+	return nil
+}
 
 // // Build component from BuildConfig.
 // // If 'wait' is true than it waits for build to successfully complete.
@@ -1367,22 +1383,22 @@ func Exists(client *kclient.Client, componentName, applicationName string) (bool
 
 // }
 
-// // isEmpty checks to see if a directory is empty
-// // shamelessly taken from: https://stackoverflow.com/questions/30697324/how-to-check-if-directory-on-path-is-empty
-// // this helps detect any edge cases where an empty directory is copied over
-// func isEmpty(name string) (bool, error) {
-// 	f, err := os.Open(name)
-// 	if err != nil {
-// 		return false, err
-// 	}
-// 	defer f.Close()
+// isEmpty checks to see if a directory is empty
+// shamelessly taken from: https://stackoverflow.com/questions/30697324/how-to-check-if-directory-on-path-is-empty
+// this helps detect any edge cases where an empty directory is copied over
+func isEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
 
-// 	_, err = f.Readdirnames(1) // Or f.Readdir(1)
-// 	if err == io.EOF {
-// 		return true, nil
-// 	}
-// 	return false, err // Either not empty or error, suits both cases
-// }
+	_, err = f.Readdirnames(1) // Or f.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err // Either not empty or error, suits both cases
+}
 
 // // getStorageFromConfig gets all the storage from the config
 // // returns a list of storage in storage struct format

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -270,7 +270,7 @@ func CreateFromPath(client *kclient.Client, params kclient.CreateArgs) error {
 			return err
 		}
 
-		podSelector := fmt.Sprintf("deploymentconfig=%s", selectorLabels)
+		podSelector := fmt.Sprintf("deployment=%s", selectorLabels)
 		_, err = client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return err

--- a/pkg/component/labels/labels.go
+++ b/pkg/component/labels/labels.go
@@ -1,0 +1,24 @@
+package labels
+
+import (
+	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
+)
+
+// ComponentLabel is a label key used to identify the component name
+const ComponentLabel = "app.kubernetes.io/component-name"
+
+// ComponentTypeLabel is Kubernetes label that identifies the type of a component being used
+const ComponentTypeLabel = "app.kubernetes.io/component-type"
+
+// ComponentTypeVersion is a Kubernetes label that identifies the component version
+const ComponentTypeVersion = "app.kubernetes.io/component-version"
+
+// GetLabels return labels that should be applied to every object for given component in active application
+// additional labels are used only for creating object
+// if you are creating something use additional=true
+// if you need labels to filter component that use additional=false
+func GetLabels(componentName string, applicationName string, additional bool) map[string]string {
+	labels := applabels.GetLabels(applicationName, additional)
+	labels[ComponentLabel] = componentName
+	return labels
+}

--- a/pkg/component/labels/labels_test.go
+++ b/pkg/component/labels/labels_test.go
@@ -1,0 +1,53 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	applabels "github.com/redhat-developer/odo-fork/pkg/application/labels"
+)
+
+func TestGetLabels(t *testing.T) {
+	type args struct {
+		componentName   string
+		applicationName string
+		additional      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "everything filled",
+			args: args{
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      false,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel: "applicationame",
+				ComponentLabel:             "componentname",
+			},
+		}, {
+			name: "everything with additional",
+			args: args{
+				componentName:   "componentname",
+				applicationName: "applicationame",
+				additional:      true,
+			},
+			want: map[string]string{
+				applabels.ApplicationLabel:               "applicationame",
+				applabels.AdditionalApplicationLabels[0]: "applicationame",
+				ComponentLabel:                           "componentname",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLabels(tt.args.componentName, tt.args.applicationName, tt.args.additional); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kclient/kclient_test.go
+++ b/pkg/kclient/kclient_test.go
@@ -548,8 +548,8 @@ func TestCreateService(t *testing.T) {
 				if !reflect.DeepEqual(tt.commonObjectMeta, createdSvc.ObjectMeta) {
 					t.Errorf("ObjectMeta does not match the expected name, expected: %v, got: %v", tt.commonObjectMeta, createdSvc.ObjectMeta)
 				}
-				if !reflect.DeepEqual(tt.commonObjectMeta.Name, createdSvc.Spec.Selector["deploymentconfig"]) {
-					t.Errorf("selector value does not match the expected name, expected: %s, got: %s", tt.commonObjectMeta.Name, createdSvc.Spec.Selector["deploymentconfig"])
+				if !reflect.DeepEqual(tt.commonObjectMeta.Name, createdSvc.Spec.Selector["deployment"]) {
+					t.Errorf("selector value does not match the expected name, expected: %s, got: %s", tt.commonObjectMeta.Name, createdSvc.Spec.Selector["deployment"])
 				}
 				for _, port := range tt.containerPorts {
 					found := false

--- a/pkg/kclient/templates.go
+++ b/pkg/kclient/templates.go
@@ -99,6 +99,11 @@ func generateDeployment(commonObjectMeta metav1.ObjectMeta, commonImageMeta Comm
 		"codewindApp": commonObjectMeta.Name,
 	}
 
+	imageRef := commonImageMeta.Name + ":" + commonImageMeta.Tag
+	if len(commonImageMeta.Namespace) > 0 {
+		imageRef = commonImageMeta.Namespace + "/" + imageRef
+	}
+
 	replicas := int32(1)
 	// Generates and deploys a DeploymentConfig with an InitContainer to copy over the SupervisorD binary.
 	deployment := appsv1.Deployment{
@@ -120,7 +125,7 @@ func generateDeployment(commonObjectMeta metav1.ObjectMeta, commonImageMeta Comm
 					Containers: []corev1.Container{
 						{
 							Name:  commonObjectMeta.Name,
-							Image: commonImageMeta.Name + ":" + commonImageMeta.Tag,
+							Image: imageRef,
 							Env:   envVar,
 							Ports: commonImageMeta.Ports,
 						},

--- a/pkg/kclient/templates.go
+++ b/pkg/kclient/templates.go
@@ -95,8 +95,8 @@ func generateDeployment(commonObjectMeta metav1.ObjectMeta, commonImageMeta Comm
 	envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, resourceRequirements *corev1.ResourceRequirements) appsv1.Deployment {
 
 	labels := map[string]string{
-		"app":         commonObjectMeta.Name,
-		"codewindApp": commonObjectMeta.Name,
+		"app":        commonObjectMeta.Name,
+		"deployment": commonObjectMeta.Name,
 	}
 
 	imageRef := commonImageMeta.Name + ":" + commonImageMeta.Tag

--- a/pkg/kclient/templates.go
+++ b/pkg/kclient/templates.go
@@ -1,0 +1,146 @@
+package kclient
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/redhat-developer/odo-fork/pkg/config"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CommonImageMeta has all the most common image data that is passed around within Odo
+type CommonImageMeta struct {
+	Name      string
+	Tag       string
+	Namespace string
+	Ports     []corev1.ContainerPort
+}
+
+// GetResourceRequirementsFromCmpSettings converts the cpu and memory request info from component configuration into format usable in dc
+// Parameters:
+//	cfg: Compoennt configuration/settings
+// Returns:
+//	*corev1.ResourceRequirements: component configuration converted into format usable in dc
+func GetResourceRequirementsFromCmpSettings(cfg config.LocalConfigInfo) (*corev1.ResourceRequirements, error) {
+	var resourceRequirements corev1.ResourceRequirements
+	requests := make(corev1.ResourceList)
+	limits := make(corev1.ResourceList)
+
+	cfgMinCPU := cfg.GetMinCPU()
+	cfgMaxCPU := cfg.GetMaxCPU()
+	cfgMinMemory := cfg.GetMinMemory()
+	cfgMaxMemory := cfg.GetMaxMemory()
+
+	if cfgMinCPU != "" {
+		minCPU, err := parseResourceQuantity(cfgMinCPU)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse the min cpu")
+		}
+		requests[corev1.ResourceCPU] = minCPU
+	}
+
+	if cfgMaxCPU != "" {
+		maxCPU, err := parseResourceQuantity(cfgMaxCPU)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse max cpu")
+		}
+		limits[corev1.ResourceCPU] = maxCPU
+	}
+
+	if cfgMinMemory != "" {
+		minMemory, err := parseResourceQuantity(cfgMinMemory)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse min memory")
+		}
+		requests[corev1.ResourceMemory] = minMemory
+	}
+
+	if cfgMaxMemory != "" {
+		maxMemory, err := parseResourceQuantity(cfgMaxMemory)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse max memory")
+		}
+		limits[corev1.ResourceMemory] = maxMemory
+	}
+
+	if len(limits) > 0 {
+		resourceRequirements.Limits = limits
+	}
+
+	if len(requests) > 0 {
+		resourceRequirements.Requests = requests
+	}
+
+	return &resourceRequirements, nil
+}
+
+// parseResourceQuantity takes a string representation of quantity/amount of a resource and returns kubernetes representation of it and errors if any
+// This is a wrapper around the kube client provided ParseQuantity added to in future support more units and make it more readable
+func parseResourceQuantity(resQuantity string) (resource.Quantity, error) {
+	return resource.ParseQuantity(resQuantity)
+}
+
+// generateSupervisordDeploymentConfig generates dc for local and binary components
+// Parameters:
+//	commonObjectMeta: Contains annotations and labels for dc
+//	commonImageMeta: Contains details like image NS, name, tag and ports to be exposed
+//	envVar: env vars to be exposed
+//	resourceRequirements: Container cpu and memory resource requirements
+// Returns:
+//	deployment config generated using above parameters
+func generateDeployment(commonObjectMeta metav1.ObjectMeta, commonImageMeta CommonImageMeta,
+	envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, resourceRequirements *corev1.ResourceRequirements) appsv1.Deployment {
+
+	labels := map[string]string{
+		"app":         commonObjectMeta.Name,
+		"codewindApp": commonObjectMeta.Name,
+	}
+
+	replicas := int32(1)
+	// Generates and deploys a DeploymentConfig with an InitContainer to copy over the SupervisorD binary.
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: commonObjectMeta,
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  commonObjectMeta.Name,
+							Image: commonImageMeta.Name + ":" + commonImageMeta.Tag,
+							Env:   envVar,
+							Ports: commonImageMeta.Ports,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	containerIndex := -1
+	if resourceRequirements != nil {
+		for index, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == commonObjectMeta.Name {
+				containerIndex = index
+				break
+			}
+		}
+		if containerIndex != -1 {
+			deployment.Spec.Template.Spec.Containers[containerIndex].Resources = *resourceRequirements
+		}
+	}
+	return deployment
+}

--- a/pkg/kclient/templates.go
+++ b/pkg/kclient/templates.go
@@ -83,14 +83,14 @@ func parseResourceQuantity(resQuantity string) (resource.Quantity, error) {
 	return resource.ParseQuantity(resQuantity)
 }
 
-// generateSupervisordDeploymentConfig generates dc for local and binary components
+// generateDeployment generates a deployment for local and binary components
 // Parameters:
 //	commonObjectMeta: Contains annotations and labels for dc
 //	commonImageMeta: Contains details like image NS, name, tag and ports to be exposed
 //	envVar: env vars to be exposed
 //	resourceRequirements: Container cpu and memory resource requirements
 // Returns:
-//	deployment config generated using above parameters
+//	deployment generated using above parameters
 func generateDeployment(commonObjectMeta metav1.ObjectMeta, commonImageMeta CommonImageMeta,
 	envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, resourceRequirements *corev1.ResourceRequirements) appsv1.Deployment {
 

--- a/pkg/kdo/cli/cli.go
+++ b/pkg/kdo/cli/cli.go
@@ -103,6 +103,7 @@ func NewCmdKdo(name, fullName string) *cobra.Command {
 		catalog.NewCmdCatalog(catalog.RecommendedCommandName, kdoutil.GetFullName(fullName, catalog.RecommendedCommandName)),
 		common.CmdPrintKdo,
 		component.NewCmdCreate(component.CreateRecommendedCommandName, kdoutil.GetFullName(fullName, component.CreateRecommendedCommandName)),
+		component.NewCmdPush(component.PushRecommendedCommandName, kdoutil.GetFullName(fullName, component.PushRecommendedCommandName)),
 		version.NewCmdVersion(version.RecommendedCommandName, kdoutil.GetFullName(fullName, version.RecommendedCommandName)),
 		config.NewCmdConfiguration(config.RecommendedCommandName, kdoutil.GetFullName(fullName, config.RecommendedCommandName)),
 	)

--- a/pkg/kdo/cli/component/create.go
+++ b/pkg/kdo/cli/component/create.go
@@ -467,7 +467,7 @@ func (co *CreateOptions) Run() (err error) {
 		if err != nil {
 			return errors.Wrap(err, "unable to set source information")
 		}
-		// TODO implement for KDO
+		// TODO-KDO:
 		return errors.Wrapf(err, "TODO implement for KDO")
 		// err = co.Push()
 		// if err != nil {
@@ -570,7 +570,7 @@ func NewCmdCreate(name, fullName string) *cobra.Command {
 	componentCreateCmd.Annotations = map[string]string{"command": "component"}
 	componentCreateCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// TODO implement for KDO
+	// TODO-KDO:
 
 	// Adding `--now` flag
 	genericclioptions.AddNowFlag(componentCreateCmd, &co.now)

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -1,0 +1,320 @@
+package component
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/fatih/color"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-developer/odo-fork/pkg/component"
+	"github.com/redhat-developer/odo-fork/pkg/config"
+	"github.com/redhat-developer/odo-fork/pkg/kclient"
+	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
+
+	// "github.com/redhat-developer/odo-fork/pkg/kdo/util/completion"
+	"github.com/redhat-developer/odo-fork/pkg/log"
+	"github.com/redhat-developer/odo-fork/pkg/project"
+	"github.com/redhat-developer/odo-fork/pkg/util"
+
+	odoutil "github.com/redhat-developer/odo-fork/pkg/kdo/util"
+
+	ktemplates "k8s.io/kubectl/pkg/util/templates"
+)
+
+var pushCmdExample = ktemplates.Examples(`  # Push source code to the current component
+%[1]s
+
+# Push data to the current component from the original source.
+%[1]s
+
+# Push source code in ~/mycode to component called my-component
+%[1]s my-component --context ~/mycode
+  `)
+
+// PushRecommendedCommandName is the recommended push command name
+const PushRecommendedCommandName = "push"
+
+// PushOptions encapsulates options that push command uses
+type PushOptions struct {
+	ignores []string
+	show    bool
+
+	sourceType       config.SrcType
+	sourcePath       string
+	componentContext string
+	client           *kclient.Client
+	localConfig      *config.LocalConfigInfo
+
+	pushConfig bool
+	pushSource bool
+
+	*genericclioptions.Context
+}
+
+// NewPushOptions returns new instance of PushOptions
+// with "default" values for certain values, for example, show is "false"
+func NewPushOptions() *PushOptions {
+	return &PushOptions{
+		show: false,
+	}
+}
+
+// Complete completes push args
+func (po *PushOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
+	po.resolveSrcAndConfigFlags()
+
+	conf, err := config.NewLocalConfigInfo(po.componentContext)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve configuration information")
+	}
+
+	// Set the necessary values within WatchOptions
+	po.localConfig = conf
+	po.sourceType = conf.LocalConfig.GetSourceType()
+
+	glog.V(4).Infof("SourceLocation: %s", po.localConfig.GetSourceLocation())
+
+	// Get SourceLocation here...
+	po.sourcePath, err = conf.GetOSSourcePath()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve absolute path to source location")
+	}
+
+	glog.V(4).Infof("Source Path: %s", po.sourcePath)
+
+	// Apply ignore information
+	err = genericclioptions.ApplyIgnore(&po.ignores, po.sourcePath)
+	if err != nil {
+		return errors.Wrap(err, "unable to apply ignore information")
+	}
+
+	// Set the correct context
+	po.Context = genericclioptions.NewContextCreatingAppIfNeeded(cmd)
+
+	// check if project exist
+	prjName := po.localConfig.GetProject()
+	isPrjExists, err := project.Exists(po.Context.Client, prjName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if project with name %s exists", prjName)
+	}
+	if !isPrjExists {
+		log.Successf("Creating project %s", prjName)
+		err = project.Create(po.Context.Client, prjName, true)
+		if err != nil {
+			log.Errorf("Failed creating project %s", prjName)
+			return errors.Wrapf(
+				err,
+				"project %s does not exist. Failed creating it.Please try after creating project using `odo project create <project_name>`",
+				prjName,
+			)
+		}
+		log.Successf("Successfully created project %s", prjName)
+	}
+	po.Context.Client.Namespace = prjName
+	return
+}
+
+// Validate validates the push parameters
+func (po *PushOptions) Validate() (err error) {
+
+	log.Info("Validation")
+
+	s := log.Spinner("Validating component")
+	defer s.End(false)
+
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfig.GetComponentSettings(), false); err != nil {
+		return err
+	}
+
+	isCmpExists, err := component.Exists(po.Context.Client, po.localConfig.GetName(), po.localConfig.GetApplication())
+	if err != nil {
+		return err
+	}
+
+	if !isCmpExists && po.pushSource && !po.pushConfig {
+		return fmt.Errorf("Component %s does not exist and hence cannot push only source. Please use `odo push` without any flags or with both `--source` and `--config` flags", po.localConfig.GetName())
+	}
+
+	s.End(true)
+	return nil
+}
+
+func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) error {
+	if !po.pushConfig {
+		// Not the case of component creation or updation(with new config)
+		// So nothing to do here and hence return from here
+		return nil
+	}
+
+	cmpName := po.localConfig.GetName()
+	appName := po.localConfig.GetApplication()
+
+	// First off, we check to see if the component exists. This is ran each time we do `odo push`
+	s := log.Spinner("Checking component")
+	defer s.End(false)
+	isCmpExists, err := component.Exists(po.Context.Client, cmpName, appName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if component %s exists or not", cmpName)
+	}
+	s.End(true)
+
+	// Output the "new" section (applying changes)
+	log.Info("\nConfiguration changes")
+
+	// If the component does not exist, we will create it for the first time.
+	if !isCmpExists {
+
+		s = log.Spinner("Creating component")
+		defer s.End(false)
+
+		// Classic case of component creation
+		if err = component.CreateComponent(po.Context.Client, *po.localConfig, po.componentContext, stdout); err != nil {
+			log.Errorf(
+				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
+				cmpName,
+				err,
+			)
+			os.Exit(1)
+		}
+
+		s.End(true)
+	}
+
+	// TODO-KDO: Add when implementing update
+	// // Apply config
+	// err = component.ApplyConfig(po.Context.Client, *po.localConfig, stdout, isCmpExists)
+	// if err != nil {
+	// 	odoutil.LogErrorAndExit(err, "Failed to update config to component deployed")
+	// }
+
+	return nil
+}
+
+// Run has the logic to perform the required actions as part of command
+func (po *PushOptions) Run() (err error) {
+	stdout := color.Output
+
+	cmpName := po.localConfig.GetName()
+	appName := po.localConfig.GetApplication()
+
+	err = po.createCmpIfNotExistsAndApplyCmpConfig(stdout)
+	if err != nil {
+		return
+	}
+
+	if !po.pushSource {
+		// If source is not requested for update, return
+		return nil
+	}
+
+	log.Infof("\nPushing to component %s of type %s", cmpName, po.sourceType)
+
+	// Get SourceLocation here...
+	po.sourcePath, err = po.localConfig.GetOSSourcePath()
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve OS source path to source location")
+	}
+
+	switch po.sourceType {
+	case config.LOCAL:
+		glog.V(4).Infof("Copying directory %s to pod", po.sourcePath)
+		err = component.PushLocal(
+			po.Context.Client,
+			cmpName,
+			appName,
+			po.sourcePath,
+			os.Stdout,
+			[]string{},
+			[]string{},
+			true,
+			util.GetAbsGlobExps(po.sourcePath, po.ignores),
+			po.show,
+			component.Target{
+				SrcPath: "",
+				Paths:   []string{""},
+			},
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
+		}
+
+	case config.BINARY:
+
+		// We will pass in the directory, NOT filepath since this is a binary..
+		binaryDirectory := filepath.Dir(po.sourcePath)
+
+		glog.V(4).Infof("Copying binary file %s to pod", po.sourcePath)
+		err = component.PushLocal(
+			po.Context.Client,
+			cmpName,
+			appName,
+			binaryDirectory,
+			os.Stdout,
+			[]string{po.sourcePath},
+			[]string{},
+			true,
+			util.GetAbsGlobExps(po.sourcePath, po.ignores),
+			po.show,
+			component.Target{
+				SrcPath: "",
+				Paths:   []string{""},
+			},
+		)
+
+		if err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
+		}
+
+		// we don't need a case for building git components
+		// the build happens before deployment
+
+		return errors.Wrapf(err, fmt.Sprintf("failed to push component: %v", cmpName))
+	}
+
+	log.Success("Changes successfully pushed to component")
+	return
+}
+
+func (po *PushOptions) resolveSrcAndConfigFlags() {
+	// If neither config nor source flag is passed, update both config and source to the component
+	if !po.pushConfig && !po.pushSource {
+		po.pushConfig = true
+		po.pushSource = true
+	}
+}
+
+// NewCmdPush implements the push odo command
+func NewCmdPush(name, fullName string) *cobra.Command {
+	po := NewPushOptions()
+
+	var pushCmd = &cobra.Command{
+		Use:     fmt.Sprintf("%s [component name]", name),
+		Short:   "Push source code to a component",
+		Long:    `Push source code to a component.`,
+		Example: fmt.Sprintf(pushCmdExample, fullName),
+		Args:    cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			genericclioptions.GenericRun(po, cmd, args)
+		},
+	}
+	genericclioptions.AddContextFlag(pushCmd, &po.componentContext)
+	pushCmd.Flags().BoolVar(&po.show, "show-log", false, "If enabled, logs will be shown when built")
+	pushCmd.Flags().StringSliceVar(&po.ignores, "ignore", []string{}, "Files or folders to be ignored via glob expressions.")
+	pushCmd.Flags().BoolVar(&po.pushConfig, "config", false, "Use config flag to only apply config on to cluster")
+	pushCmd.Flags().BoolVar(&po.pushSource, "source", false, "Use source flag to only push latest source on to cluster")
+
+	// Add a defined annotation in order to appear in the help menu
+	pushCmd.Annotations = map[string]string{"command": "component"}
+	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
+	// TODO-KDO: Add when implementing completion
+	// completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)
+	// completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)
+
+	return pushCmd
+}

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -16,7 +16,6 @@ import (
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
 
-	// "github.com/redhat-developer/odo-fork/pkg/kdo/util/completion"
 	"github.com/redhat-developer/odo-fork/pkg/log"
 	"github.com/redhat-developer/odo-fork/pkg/project"
 	"github.com/redhat-developer/odo-fork/pkg/util"
@@ -312,9 +311,6 @@ func NewCmdPush(name, fullName string) *cobra.Command {
 	// Add a defined annotation in order to appear in the help menu
 	pushCmd.Annotations = map[string]string{"command": "component"}
 	pushCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
-	// TODO-KDO: Add when implementing completion
-	// completion.RegisterCommandHandler(pushCmd, completion.ComponentNameCompletionHandler)
-	// completion.RegisterCommandFlagHandler(pushCmd, "context", completion.FileCompletionHandler)
 
 	return pushCmd
 }

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/golang/glog"
@@ -18,7 +17,6 @@ import (
 
 	"github.com/redhat-developer/odo-fork/pkg/log"
 	"github.com/redhat-developer/odo-fork/pkg/project"
-	"github.com/redhat-developer/odo-fork/pkg/util"
 
 	odoutil "github.com/redhat-developer/odo-fork/pkg/kdo/util"
 
@@ -198,9 +196,6 @@ func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) e
 func (po *PushOptions) Run() (err error) {
 	stdout := color.Output
 
-	cmpName := po.localConfig.GetName()
-	appName := po.localConfig.GetApplication()
-
 	err = po.createCmpIfNotExistsAndApplyCmpConfig(stdout)
 	if err != nil {
 		return
@@ -211,70 +206,47 @@ func (po *PushOptions) Run() (err error) {
 		return nil
 	}
 
-	log.Infof("\nPushing to component %s of type %s", cmpName, po.sourceType)
+	// TODO-KDO: Implement push once the persistent volume setup is complete
+	// log.Infof("\nPushing to component %s of type %s", cmpName, po.sourceType)
 
-	// Get SourceLocation here...
-	po.sourcePath, err = po.localConfig.GetOSSourcePath()
-	if err != nil {
-		return errors.Wrap(err, "unable to retrieve OS source path to source location")
-	}
+	// // Get SourceLocation here...
+	// po.sourcePath, err = po.localConfig.GetOSSourcePath()
+	// if err != nil {
+	// 	return errors.Wrap(err, "unable to retrieve OS source path to source location")
+	// }
 
-	switch po.sourceType {
-	case config.LOCAL:
-		glog.V(4).Infof("Copying directory %s to pod", po.sourcePath)
-		err = component.PushLocal(
-			po.Context.Client,
-			cmpName,
-			appName,
-			po.sourcePath,
-			os.Stdout,
-			[]string{},
-			[]string{},
-			true,
-			util.GetAbsGlobExps(po.sourcePath, po.ignores),
-			po.show,
-			component.ContainerAttributes{ // TODO-KDO: Retrieve container attributes from IDP
-				SrcPath:      "",
-				WorkingPaths: []string{""},
-			},
-		)
+	// cmpName := po.localConfig.GetName()
+	// appName := po.localConfig.GetApplication()
 
-		if err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
-		}
+	// switch po.sourceType {
+	// case config.LOCAL:
+	// 	glog.V(4).Infof("Copying directory %s to pod", po.sourcePath)
+	// 	err = component.PushLocal(
+	// 		po.Context.Client,
+	// 		cmpName,
+	// 		appName,
+	// 		po.sourcePath,
+	// 		os.Stdout,
+	// 		[]string{},
+	// 		[]string{},
+	// 		true,
+	// 		util.GetAbsGlobExps(po.sourcePath, po.ignores),
+	// 		po.show,
+	// 		component.ContainerAttributes{ // TODO-KDO: Retrieve container attributes from IDP
+	// 			SrcPath:      "",
+	// 			WorkingPaths: []string{""},
+	// 		},
+	// 	)
 
-	case config.BINARY:
+	// 	if err != nil {
+	// 		return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
+	// 	}
 
-		// We will pass in the directory, NOT filepath since this is a binary..
-		binaryDirectory := filepath.Dir(po.sourcePath)
-
-		glog.V(4).Infof("Copying binary file %s to pod", po.sourcePath)
-		err = component.PushLocal(
-			po.Context.Client,
-			cmpName,
-			appName,
-			binaryDirectory,
-			os.Stdout,
-			[]string{po.sourcePath},
-			[]string{},
-			true,
-			util.GetAbsGlobExps(po.sourcePath, po.ignores),
-			po.show,
-			component.ContainerAttributes{ // TODO-KDO: Retrieve container attributes from IDP
-				SrcPath:      "",
-				WorkingPaths: []string{""},
-			},
-		)
-
-		if err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("Failed to push component: %v", cmpName))
-		}
-
-		// we don't need a case for building git components
-		// the build happens before deployment
-
-		return errors.Wrapf(err, fmt.Sprintf("failed to push component: %v", cmpName))
-	}
+	// default:
+	// 	if err != nil {
+	// 		return errors.Wrapf(err, fmt.Sprintf("Failed to push component %v because the source type is not recognized", cmpName))
+	// 	}
+	// }
 
 	log.Success("Changes successfully pushed to component")
 	return

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -234,9 +234,9 @@ func (po *PushOptions) Run() (err error) {
 			true,
 			util.GetAbsGlobExps(po.sourcePath, po.ignores),
 			po.show,
-			component.Target{
-				SrcPath: "",
-				Paths:   []string{""},
+			component.ContainerAttributes{ // TODO-KDO: Retrieve container attributes from IDP
+				SrcPath:      "",
+				WorkingPaths: []string{""},
 			},
 		)
 
@@ -261,9 +261,9 @@ func (po *PushOptions) Run() (err error) {
 			true,
 			util.GetAbsGlobExps(po.sourcePath, po.ignores),
 			po.show,
-			component.Target{
-				SrcPath: "",
-				Paths:   []string{""},
+			component.ContainerAttributes{ // TODO-KDO: Retrieve container attributes from IDP
+				SrcPath:      "",
+				WorkingPaths: []string{""},
 			},
 		)
 

--- a/pkg/kdo/cli/project/project.go
+++ b/pkg/kdo/cli/project/project.go
@@ -62,11 +62,6 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 	projectCmd.Annotations = map[string]string{"command": "main"}
 	projectCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// TODO-KDO:
-
-	// completion.RegisterCommandHandler(projectSetCmd, completion.ProjectNameCompletionHandler)
-	// completion.RegisterCommandHandler(projectDeleteCmd, completion.ProjectNameCompletionHandler)
-
 	return projectCmd
 }
 

--- a/pkg/kdo/cli/project/project.go
+++ b/pkg/kdo/cli/project/project.go
@@ -3,17 +3,8 @@ package project
 import (
 	"fmt"
 
-	// "github.com/redhat-developer/odo-fork/pkg/application"
-	// "github.com/redhat-developer/odo-fork/pkg/component"
-
-	// "github.com/redhat-developer/odo-fork/pkg/kclient"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
 	odoutil "github.com/redhat-developer/odo-fork/pkg/kdo/util"
-
-	// "github.com/redhat-developer/odo-fork/pkg/kdo/util/completion"
-
-	// "github.com/redhat-developer/odo-fork/pkg/service"
-	// "github.com/redhat-developer/odo-fork/pkg/url"
 
 	"github.com/spf13/cobra"
 )
@@ -69,78 +60,4 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 // Also adds a completion handler to the flag
 func AddProjectFlag(cmd *cobra.Command) {
 	cmd.Flags().String(genericclioptions.ProjectFlagName, "", "Project, defaults to active project")
-	// TODO-KDO:
-
-	// completion.RegisterCommandFlagHandler(cmd, "project", completion.ProjectNameCompletionHandler)
 }
-
-// printDeleteProjectInfo prints objects affected by project deletion
-// func printDeleteProjectInfo(client *kclient.Client, projectName string) error {
-// 	localConfig, err := config.New()
-// 	if err != nil {
-// 		return errors.Wrapf(err, "unable to get the local config")
-// 	}
-// 	// Fetch and List the applications
-// 	applicationList, err := application.ListInProject(client)
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to get application list")
-// 	}
-// 	if len(applicationList) != 0 {
-// 		log.Info("This project contains the following applications, which will be deleted")
-// 		for _, app := range applicationList {
-// 			log.Info("Application", app)
-
-// 			// List the components
-// 			componentList, err := component.List(client, app)
-// 			if err != nil {
-// 				return errors.Wrap(err, "failed to get Component list")
-// 			}
-// 			if len(componentList.Items) != 0 {
-// 				log.Info("This application has following components that will be deleted")
-
-// 				for _, currentComponent := range componentList.Items {
-// 					componentDesc, err := component.GetComponent(client, currentComponent.Name, app, projectName)
-// 					if err != nil {
-// 						return errors.Wrap(err, "unable to get component description")
-// 					}
-// 					log.Info("component named", componentDesc.Name)
-
-// 					if len(componentDesc.Spec.URL) != 0 {
-// 						ul, err := url.List(client, componentDesc.Name, app)
-// 						if err != nil {
-// 							return errors.Wrap(err, "Could not get url list")
-// 						}
-// 						log.Info("This component has following urls that will be deleted with component")
-// 						for _, u := range ul.Items {
-// 							log.Info("URL named", u.GetName(), "with host", u.Spec.Host, "having protocol", u.Spec.Protocol, "at port", u.Spec.Port)
-// 						}
-// 					}
-
-// 					storages, err := localConfig.StorageList()
-// 					odoutil.LogErrorAndExit(err, "")
-// 					if len(storages) != 0 {
-// 						log.Info("This component has following storages which will be deleted with the component")
-// 						for _, store := range storages {
-// 							log.Info("Storage named", store.Name, "of size", store.Size)
-// 						}
-// 					}
-// 				}
-// 			}
-
-// 			// List services that will be removed
-// 			serviceList, err := service.List(client, app)
-// 			if err != nil {
-// 				log.Info("No services / could not get services")
-// 				glog.V(4).Info(err.Error())
-// 			}
-
-// 			if len(serviceList) != 0 {
-// 				log.Info("This application has following service that will be deleted")
-// 				for _, ser := range serviceList {
-// 					log.Info("service named", ser.Name, "of type", ser.Type)
-// 				}
-// 			}
-// 		}
-// 	}
-// 	return nil
-// }

--- a/pkg/kdo/cli/project/project.go
+++ b/pkg/kdo/cli/project/project.go
@@ -62,7 +62,7 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 	projectCmd.Annotations = map[string]string{"command": "main"}
 	projectCmd.SetUsageTemplate(odoutil.CmdUsageTemplate)
 
-	// TODO implement for KDO
+	// TODO-KDO:
 
 	// completion.RegisterCommandHandler(projectSetCmd, completion.ProjectNameCompletionHandler)
 	// completion.RegisterCommandHandler(projectDeleteCmd, completion.ProjectNameCompletionHandler)
@@ -74,7 +74,7 @@ func NewCmdProject(name, fullName string) *cobra.Command {
 // Also adds a completion handler to the flag
 func AddProjectFlag(cmd *cobra.Command) {
 	cmd.Flags().String(genericclioptions.ProjectFlagName, "", "Project, defaults to active project")
-	// TODO implement for KDO
+	// TODO-KDO:
 
 	// completion.RegisterCommandFlagHandler(cmd, "project", completion.ProjectNameCompletionHandler)
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -59,7 +59,7 @@ func DescribeProjects(client *kclient.Client) (ProjectList, error) {
 		if project == currentProject {
 			isActive = true
 		}
-		// TODO-KDO:
+		// TODO-KDO: Add this back when application command has been implemented
 		// apps, _ := application.ListInProject(client)
 		apps := []string{"app"}
 		projects = append(projects, GetMachineReadableFormat(project, isActive, apps))

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -59,7 +59,7 @@ func DescribeProjects(client *kclient.Client) (ProjectList, error) {
 		if project == currentProject {
 			isActive = true
 		}
-		// TODO: implement for KDO
+		// TODO-KDO:
 		// apps, _ := application.ListInProject(client)
 		apps := []string{"app"}
 		projects = append(projects, GetMachineReadableFormat(project, isActive, apps))


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Adds the `push` command. It currently only creates the deployment, service and secret for the component. It does not yet push files to the pod, that will be added in a future PR.

This PR also pulls in further ODO logic related to application, component and labels.

Added comments prefixed with `TODO-KDO:` for areas of focus for the near future.

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Clone the nodejs sample https://github.com/openshift/nodejs-ex
1. Run `kdo create`
1. Run `kdo push`

Current output should look like
```
Validation

 ✓  Validating component [5ms]

 ✓  Checking component [3ms]

Configuration changes
 ✓  Initializing component

 ✓  Creating component [73ms]
 ✓  Changes successfully pushed to component
```

Run `kubectl get all` within the project namespace. The output should contain a pod, service, deployment and replicaset. 

Run `kubectl get secret` and there should be a secret for the component.

Run the automated tests using `make test`