### PR TITLE
Rename .odo to .udo

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ func getLocalConfigFile(cfgDir string) (string, error) {
 		}
 	}
 
-	return filepath.Join(cfgDir, ".odo", configFileName), nil
+	return filepath.Join(cfgDir, ".udo", configFileName), nil
 }
 
 // New returns the localConfigInfo
@@ -631,8 +631,8 @@ func (lci *LocalConfigInfo) GetOSSourcePath() (path string, err error) {
 	sourceLocation := lci.GetSourceLocation()
 
 	// Get the component context folder
-	// ".odo" is removed as lci.Filename will always return the '.odo' folder.. we don't need that!
-	componentContext := strings.Trim(filepath.Dir(lci.Filename), ".odo")
+	// ".udo" is removed as lci.Filename will always return the '.udo' folder.. we don't need that!
+	componentContext := strings.Trim(filepath.Dir(lci.Filename), ".udo")
 
 	if sourceLocation == "" {
 		return "", fmt.Errorf("Blank source location provided")

--- a/pkg/kdo/cli/cli.go
+++ b/pkg/kdo/cli/cli.go
@@ -78,7 +78,7 @@ func NewCmdKdo(name, fullName string) *cobra.Command {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.odo.yaml)")
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.udo.yaml)")
 
 	rootCmd.PersistentFlags().Bool(genericclioptions.SkipConnectionCheckFlagName, false, "Skip cluster check")
 

--- a/pkg/kdo/cli/component/common_push.go
+++ b/pkg/kdo/cli/component/common_push.go
@@ -149,7 +149,7 @@ func (cpo *CommonPushOptions) SetSourceInfo() (err error) {
 // 	appName := cpo.localConfigInfo.GetApplication()
 
 // 	if cpo.componentContext == "" {
-// 		cpo.componentContext = strings.Trim(filepath.Dir(cpo.localConfigInfo.Filename), ".odo")
+// 		cpo.componentContext = strings.Trim(filepath.Dir(cpo.localConfigInfo.Filename), ".udo")
 // 	}
 
 // 	cmpExists, err := cpo.createCmpIfNotExistsAndApplyCmpConfig(stdout)
@@ -186,7 +186,7 @@ func (cpo *CommonPushOptions) SetSourceInfo() (err error) {
 // 		}
 
 // 		if cmpExists {
-// 			// apply the glob rules from the .gitignore/.odo file
+// 			// apply the glob rules from the .gitignore/.udo file
 // 			// and ignore the files on which the rules apply and filter them out
 // 			filesChangedFiltered, filesDeletedFiltered := filterIgnores(filesChanged, filesDeleted, absIgnoreRules)
 

--- a/pkg/kdo/cli/component/create.go
+++ b/pkg/kdo/cli/component/create.go
@@ -55,7 +55,7 @@ type CreateOptions struct {
 const CreateRecommendedCommandName = "create"
 
 // LocalDirectoryDefaultLocation is the default location of where --local files should always be..
-// since the application will always be in the same directory as `.odo`, we will always set this as: ./
+// since the application will always be in the same directory as `.udo`, we will always set this as: ./
 const LocalDirectoryDefaultLocation = "./"
 
 var createLongDesc = ktemplates.LongDesc(`Create a configuration describing a component to be deployed on OpenShift.

--- a/pkg/testingutil/configs.go
+++ b/pkg/testingutil/configs.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/redhat-developer/odo-fork/pkg/preference"
 	"github.com/pkg/errors"
+	"github.com/redhat-developer/odo-fork/pkg/preference"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -39,7 +39,7 @@ func getConfFolder() (string, error) {
 		confLocation = currentUser.HomeDir
 	}
 
-	dir, err := ioutil.TempDir(confLocation, ".odo")
+	dir, err := ioutil.TempDir(confLocation, ".udo")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/fileIndexer.go
+++ b/pkg/util/fileIndexer.go
@@ -2,14 +2,15 @@ package util
 
 import (
 	"encoding/json"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/golang/glog"
 )
 
-const fileIndexDirectory = ".odo"
+const fileIndexDirectory = ".udo"
 const fileIndexName = "odo-file-index.json"
 
 type FileData struct {
@@ -42,7 +43,7 @@ func read(filePath string) (map[string]FileData, error) {
 	return fileReadMap, nil
 }
 
-// resolveFilePath resolves the filepath of the odo index file in the .odo folder
+// resolveFilePath resolves the filepath of the odo index file in the .udo folder
 func resolveFilePath(directory string) (string, error) {
 	directoryFi, err := os.Stat(filepath.Join(directory))
 	if err != nil {
@@ -63,9 +64,9 @@ func resolveFilePath(directory string) (string, error) {
 }
 
 // Run walks the given directory and finds the files which have changed and which were deleted/renamed
-// it reads the odo index file from the .odo folder
+// it reads the odo index file from the .udo folder
 // if no such file is present, it means it's the first time the folder is being walked and thus returns a empty list
-// after the walk, it stores the list of walked files with some information in a odo index file in the .odo folder
+// after the walk, it stores the list of walked files with some information in a odo index file in the .udo folder
 func Run(directory string, ignoreRules []string) (filesChanged []string, filesDeleted []string, err error) {
 	resolvedPath, err := resolveFilePath(directory)
 	if err != nil {
@@ -97,7 +98,7 @@ func Run(directory string, ignoreRules []string) (filesChanged []string, filesDe
 			}
 
 			if fi.Name() == fileIndexDirectory || fi.Name() == ".git" {
-				glog.V(4).Info(".odo or .git directory detected, skipping it")
+				glog.V(4).Info(".udo or .git directory detected, skipping it")
 				return filepath.SkipDir
 			}
 		}


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What is the purpose of this change? What does it change?
This PR renames the `.odo` folder to `.udo`.

## Was the change discussed in an issue?
<!-- Please do Link issues here. -->
N/A

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Compile my branch with `make`
2. Run `kdo create nodejs-idp`
3. Verify a .udo folder is created and has a config.yaml in it
4. Run `kdo config set MaxCPU 5` and verify the MaxCPU field gets added to it.