### PR TITLE
Change from using lengthy commands to calling scripts from volume

### DIFF
--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -12,13 +12,14 @@ import (
 func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace string, idpClaimName string, projectSubPath string, projectName string) (*batchv1.Job, error) {
 	fmt.Printf("Creating job %s\n", buildTaskJob)
 	// Create a Kube job to run mvn package for a Liberty project
-	command := "/data/idp/bin/build-container-full.sh"
+	command := []string{"/bin/sh", "-c"}
+	commandArgs := []string{"/data/idp/bin/build-container-full.sh"}
 
 	if taskName == "inc" {
-		command = "/data/idp/bin/build-container-update.sh"
+		commandArgs = []string{"/data/idp/bin/build-container-update.sh"}
 	}
 
-	fmt.Printf("Command: %s\n", command)
+	fmt.Printf("Command: %s %s\n", command, commandArgs)
 	backoffLimit := int32(1)
 	parallelism := int32(1)
 	job := &batchv1.Job{
@@ -44,8 +45,8 @@ func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace stri
 							Name:            "maven-build",
 							Image:           "docker.io/maven:3.6",
 							ImagePullPolicy: corev1.PullAlways,
-							Command:         []string{"/bin/sh", "-c"},
-							Args:            []string{command},
+							Command:         command,
+							Args:            commandArgs,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "idp-volume",

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -12,10 +12,10 @@ import (
 func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace string, idpClaimName string, projectSubPath string, projectName string) (*batchv1.Job, error) {
 	fmt.Printf("Creating job %s\n", buildTaskJob)
 	// Create a Kube job to run mvn package for a Liberty project
-	command := "/data/idp/scripts/build-container-full.sh"
+	command := "/data/idp/bin/build-container-full.sh"
 
 	if taskName == "inc" {
-		command = "/data/idp/scripts/build-container-update.sh"
+		command = "/data/idp/bin/build-container-update.sh"
 	}
 
 	fmt.Printf("Command: %s\n", command)

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -12,13 +12,13 @@ import (
 func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace string, idpClaimName string, projectSubPath string, projectName string) (*batchv1.Job, error) {
 	fmt.Printf("Creating job %s\n", buildTaskJob)
 	// Create a Kube job to run mvn package for a Liberty project
-	mvnCommand := "echo listing /data/idp/src && ls -la /data/idp/src && echo copying /data/idp/src to /tmp/app && cp -rf /data/idp/src /tmp/app && echo chown, listing and running mvn in /tmp/app: && chown -fR 1001 /tmp/app && cd /tmp/app && ls -la && mvn -B clean package -Dmaven.repo.local=/data/idp/cache/.m2/repository -DskipTests=true && echo copying target to output dir && rm -rf /data/idp/output && mkdir -p /data/idp/output && cp -rf /tmp/app/target /data/idp/output && chown -fR 1001 /data/idp/output && echo listing /data/idp/output after mvn and chown 1001 buildoutput && ls -la /data/idp/output/target && echo rm -rf /data/idp/buildartifacts and copying artifacts && rm -rf /data/idp/buildartifacts && mkdir -p /data/idp/buildartifacts/ && cp -r /data/idp/output/target/liberty/wlp/usr/servers/defaultServer/* /data/idp/buildartifacts/ && cp -r /data/idp/output/target/liberty/wlp/usr/shared/resources/ /data/idp/buildartifacts/ && cp /data/idp/src/src/main/liberty/config/jvmbx.options /data/idp/buildartifacts/jvm.options && echo chown the buildartifacts dir && chown -fR 1001 /data/idp/buildartifacts"
+	command := "/data/idp/scripts/build-container-full.sh"
 
 	if taskName == "inc" {
-		mvnCommand = "echo listing /data/idp/src && ls -la /data/idp/src && echo copying /data/idp/src to /tmp/app && cp -rf /data/idp/src /tmp/app && echo chown, listing and running mvn in /tmp/app: && chown -fR 1001 /tmp/app && cd /tmp/app && ls -la && mvn -B clean package -Dmaven.repo.local=/data/idp/cache/.m2/repository -DskipTests=true && echo copying target to output dir && rm -rf /data/idp/output && mkdir -p /data/idp/output && cp -rf /tmp/app/target /data/idp/output && chown -fR 1001 /data/idp/output && echo listing /data/idp/output after mvn and chown 1001 buildoutput && ls -la /data/idp/output/target && echo copying artifacts && cp -rf /data/idp/output/target/liberty/wlp/usr/servers/defaultServer/apps/* /data/idp/buildartifacts/apps/ && echo chown the buildartifacts apps dir && chown -fR 1001 /data/idp/buildartifacts/apps"
+		command = "/data/idp/scripts/build-container-update.sh"
 	}
 
-	fmt.Printf("Mvn Command: %s\n", mvnCommand)
+	fmt.Printf("Command: %s\n", command)
 	backoffLimit := int32(1)
 	parallelism := int32(1)
 	job := &batchv1.Job{
@@ -45,7 +45,7 @@ func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace stri
 							Image:           "docker.io/maven:3.6",
 							ImagePullPolicy: corev1.PullAlways,
 							Command:         []string{"/bin/sh", "-c"},
-							Args:            []string{mvnCommand},
+							Args:            []string{command},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "idp-volume",


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
The commands to be executed for a build task will eventually come from the IDP definition. This is an intermediate step that will use scripts mounted to the IDP volume under the `/data/idp/bin` folder.

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Copy the scripts from https://github.com/redhat-developer/odo-fork/tree/microprofile-idp into the IDP volume.
1. You can then run `./kdo build full projA false` and `./kdo build inc projA false` to test.