### PR TITLE
Rename to udo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ bin
 !kdo/
 !udo/
 
+# Ignore .udo folder
+.udo/
+
 # Ignore coverage report
 coverage.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@
 
 # Ignore compiled files
 kdo
+udo
 dist
 bin
 
 # Un-ignore odo directories
 !kdo/
+!udo/
 
 # Ignore coverage report
 coverage.txt

--- a/.udo/config.yaml
+++ b/.udo/config.yaml
@@ -1,9 +1,0 @@
-kind: LocalConfig
-apiversion: odo.openshift.io/v1alpha1
-ComponentSettings:
-  Type: nodejs-idp
-  SourceLocation: ./
-  SourceType: local
-  Application: app
-  Project: che
-  Name: nodejs-idp-kdo-vwiq

--- a/.udo/config.yaml
+++ b/.udo/config.yaml
@@ -1,0 +1,9 @@
+kind: LocalConfig
+apiversion: odo.openshift.io/v1alpha1
+ComponentSettings:
+  Type: nodejs-idp
+  SourceLocation: ./
+  SourceType: local
+  Application: app
+  Project: che
+  Name: nodejs-idp-kdo-vwiq

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT := github.com/redhat-developer/kdo
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 PKGS := $(shell go list  ./... | grep -v $(PROJECT)/vendor | grep -v $(PROJECT)/tests )
-COMMON_FLAGS := -X $(PROJECT)/pkg/kdo/cli/version.GITCOMMIT=$(GITCOMMIT)
+COMMON_FLAGS := -X $(PROJECT)/pkg/udo/cli/version.GITCOMMIT=$(GITCOMMIT)
 BUILD_FLAGS := -ldflags="-w $(COMMON_FLAGS)"
 DEBUG_BUILD_FLAGS := -ldflags="$(COMMON_FLAGS)"
 FILES := odo dist
@@ -11,11 +11,11 @@ default: bin
 
 .PHONY: bin
 bin:
-	go build ${BUILD_FLAGS} cmd/kdo/kdo.go
+	go build ${BUILD_FLAGS} cmd/udo/udo.go
 
 .PHONY: install
 install:
-	go install ${BUILD_FLAGS} ./cmd/kdo/
+	go install ${BUILD_FLAGS} ./cmd/udo/
 
 .PHONY: clean
 clean:

--- a/cmd/udo/udo.go
+++ b/cmd/udo/udo.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	var root = cli.NewCmdKdo(cli.KdoRecommendedName, cli.KdoRecommendedName)
+	var root = cli.NewCmdUdo(cli.UdoRecommendedName, cli.UdoRecommendedName)
 
 	// override usage so that flag.Parse uses root command's usage instead of default one when invoked with -h
 	root.Flags().AddGoFlagSet(flag.CommandLine)

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -13,7 +13,7 @@ import (
 const (
 	appPrefixMaxLen   = 12
 	appNameMaxRetries = 3
-	appAPIVersion     = "apps.kdo.io/v1alpha1"
+	appAPIVersion     = "apps.udo.io/v1alpha1"
 	appKind           = "app"
 	appList           = "List"
 )

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -30,7 +30,7 @@ type CatalogEntry struct {
 func List() ([]CatalogEntry, error) {
 	// See if we have an index.json already cached
 	var idpList []CatalogEntry
-	indexJSONFile := path.Join(os.TempDir(), ".kdo", "index.json")
+	indexJSONFile := path.Join(os.TempDir(), ".udo", "index.json")
 
 	// Load the index.json file into memory
 	var jsonBytes []byte
@@ -120,7 +120,7 @@ func VersionExists(client *kclient.Client, idpName string, idpVersion string) (b
 	return false, nil
 }
 
-// downloadIDPs downloads the index.json to a temp directory for KDO to access
+// downloadIDPs downloads the index.json to a temp directory for UDO to access
 func downloadIDPs() ([]byte, error) {
 	// Download the IDP index.json
 	var httpClient = &http.Client{Timeout: 10 * time.Second}

--- a/pkg/common/KdoCommand.go
+++ b/pkg/common/KdoCommand.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 )
 
-// CmdPrintKdo External command
-var CmdPrintKdo = &cobra.Command{
-	Use:   "printkdo [string to print]",
+// CmdPrintUdo External command
+var CmdPrintUdo = &cobra.Command{
+	Use:   "printudo [string to print]",
 	Short: "Print anything to the screen",
 	Long: `print is for printing anything back to the screen.
 For many years people have printed back to the screen.`,
 	Args: cobra.MinimumNArgs(1),
-	Run:  kdoPrint,
+	Run:  udoPrint,
 }
 
-var kdoPrint = func(cmd *cobra.Command, args []string) {
-	fmt.Println("kdo: " + strings.Join(args, " "))
+var udoPrint = func(cmd *cobra.Command, args []string) {
+	fmt.Println("udo: " + strings.Join(args, " "))
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -500,7 +500,7 @@ func ValidateComponentCreateRequest(client *kclient.Client, componentSettings co
 		return errors.Wrapf(err, "Failed to create component of type %s", componentType)
 	}
 	if !exists {
-		log.Info("Run 'kdo catalog list idp' for a list of supported Iterative-Dev packs")
+		log.Info("Run 'udo catalog list idp' for a list of supported Iterative-Dev packs")
 		return fmt.Errorf("Failed to find component of type %s", componentType)
 	}
 
@@ -510,7 +510,7 @@ func ValidateComponentCreateRequest(client *kclient.Client, componentSettings co
 		return errors.Wrapf(err, "Failed to create component of type %s of version %s", componentType, componentVersion)
 	}
 	if !versionExists {
-		log.Info("Run 'kdo catalog list idp' to see a list of supported component type versions")
+		log.Info("Run 'udo catalog list idp' to see a list of supported component type versions")
 		return fmt.Errorf("Invalid component version %s:%s", componentType, componentVersion)
 	}
 

--- a/pkg/kdo/cli/catalog/list/idp.go
+++ b/pkg/kdo/cli/catalog/list/idp.go
@@ -14,7 +14,7 @@ const idpRecommendedCommandName = "idp"
 
 var idpsExample = `  # Get the supported Iterative-dev Packs`
 
-// ListIDPOptions encapsulates the options for the kdo catalog list idp command
+// ListIDPOptions encapsulates the options for the udo catalog list idp command
 type ListIDPOptions struct {
 	// list of known images
 	catalogList []catalog.CatalogEntry
@@ -61,7 +61,7 @@ func (o *ListIDPOptions) Run() (err error) {
 	return
 }
 
-// NewCmdCatalogListIDPs implements the kdo catalog list idps command
+// NewCmdCatalogListIDPs implements the udo catalog list idps command
 func NewCmdCatalogListIDPs(name, fullName string) *cobra.Command {
 	o := NewListIDPOptions()
 

--- a/pkg/kdo/cli/catalog/list/list.go
+++ b/pkg/kdo/cli/catalog/list/list.go
@@ -10,7 +10,7 @@ import (
 // RecommendedCommandName is the recommended command name
 const RecommendedCommandName = "list"
 
-// NewCmdCatalogList implements the kdo catalog list command
+// NewCmdCatalogList implements the udo catalog list command
 func NewCmdCatalogList(name, fullName string) *cobra.Command {
 	idp := NewCmdCatalogListIDPs(idpRecommendedCommandName, util.GetFullName(fullName, idpRecommendedCommandName))
 

--- a/pkg/kdo/cli/catalog/search/idp.go
+++ b/pkg/kdo/cli/catalog/search/idp.go
@@ -14,7 +14,7 @@ const idpRecommendedCommandName = "idp"
 var idpExample = `  # Search for an iterative-dev pack
   %[1]s python`
 
-// SearchIDPOptions encapsulates the options for the kdo catalog search idp command
+// SearchIDPOptions encapsulates the options for the udo catalog search idp command
 type SearchIDPOptions struct {
 	searchTerm string
 	idps       []string
@@ -52,7 +52,7 @@ func (o *SearchIDPOptions) Run() (err error) {
 	return
 }
 
-// NewCmdCatalogSearchIDP implements the kdo catalog search idp command
+// NewCmdCatalogSearchIDP implements the udo catalog search idp command
 func NewCmdCatalogSearchIDP(name, fullName string) *cobra.Command {
 	o := NewSearchIDPOptions()
 	return &cobra.Command{

--- a/pkg/kdo/cli/catalog/search/search.go
+++ b/pkg/kdo/cli/catalog/search/search.go
@@ -10,7 +10,7 @@ import (
 // RecommendedCommandName is the recommended command name
 const RecommendedCommandName = "search"
 
-// NewCmdCatalogSearch implements the kdo catalog search command
+// NewCmdCatalogSearch implements the udo catalog search command
 func NewCmdCatalogSearch(name, fullName string) *cobra.Command {
 	component := NewCmdCatalogSearchIDP(idpRecommendedCommandName, util.GetFullName(fullName, idpRecommendedCommandName))
 	catalogSearchCmd := &cobra.Command{

--- a/pkg/kdo/cli/cli.go
+++ b/pkg/kdo/cli/cli.go
@@ -23,7 +23,7 @@ const UdoRecommendedName = "udo"
 
 var (
 	udoLong = ktemplates.LongDesc(`
-(Universal Do) udo is a CLI tool for running Kubernetes applications in a fast and automated matter. Reducing the complexity of deployment, udo adds iterative development without the worry of deploying your source code.
+(Universal Do) udo is a CLI tool for running cloud native applications in a fast and automated matter. Reducing the complexity of deployment, udo adds iterative development without the worry of deploying your source code.
 
 Find more information at https://github.com/redhat-developer/odo-fork`)
 	udoExample = ktemplates.Examples(`  # Creating and deploying a Node.js project

--- a/pkg/kdo/cli/cli.go
+++ b/pkg/kdo/cli/cli.go
@@ -18,15 +18,15 @@ import (
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 )
 
-// KdoRecommendedName is the recommended kdo command name
-const KdoRecommendedName = "kdo"
+// udoRecommendedName is the recommended udo command name
+const UdoRecommendedName = "udo"
 
 var (
-	kdoLong = ktemplates.LongDesc(`
-(Kubernetes Do) kdo is a CLI tool for running Kubernetes applications in a fast and automated matter. Reducing the complexity of deployment, kdo adds iterative development without the worry of deploying your source code.
+	udoLong = ktemplates.LongDesc(`
+(Universal Do) udo is a CLI tool for running Kubernetes applications in a fast and automated matter. Reducing the complexity of deployment, udo adds iterative development without the worry of deploying your source code.
 
 Find more information at https://github.com/redhat-developer/odo-fork`)
-	kdoExample = ktemplates.Examples(`  # Creating and deploying a Node.js project
+	udoExample = ktemplates.Examples(`  # Creating and deploying a Node.js project
   git clone https://github.com/openshift/nodejs-ex && cd nodejs-ex
   %[1]s create nodejs
   %[1]s push
@@ -65,14 +65,14 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 `
 )
 
-// NewCmdKdo creates a new root command for kdo
-func NewCmdKdo(name, fullName string) *cobra.Command {
+// NewCmdudo creates a new root command for udo
+func NewCmdUdo(name, fullName string) *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
 		Use:     name,
-		Short:   "kdo (Kubernetes Do)",
-		Long:    kdoLong,
-		Example: fmt.Sprintf(kdoExample, fullName),
+		Short:   "udo (Universal Do)",
+		Long:    udoLong,
+		Example: fmt.Sprintf(udoExample, fullName),
 	}
 
 	// Here you will define your flags and configuration settings.
@@ -101,7 +101,7 @@ func NewCmdKdo(name, fullName string) *cobra.Command {
 
 	rootCmd.AddCommand(
 		catalog.NewCmdCatalog(catalog.RecommendedCommandName, kdoutil.GetFullName(fullName, catalog.RecommendedCommandName)),
-		common.CmdPrintKdo,
+		common.CmdPrintUdo,
 		component.NewCmdCreate(component.CreateRecommendedCommandName, kdoutil.GetFullName(fullName, component.CreateRecommendedCommandName)),
 		component.NewCmdPush(component.PushRecommendedCommandName, kdoutil.GetFullName(fullName, component.PushRecommendedCommandName)),
 		component.NewCmdBuild(component.BuildRecommendedCommandName, kdoutil.GetFullName(fullName, component.BuildRecommendedCommandName)),

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -27,7 +27,7 @@ var buildCmdExample = ktemplates.Examples(`  # Command for a full-build
 %[1]s inc <project name> <reuse build container>
   `)
 
-// BuildIDPOptions encapsulates the options for the kdo catalog list idp command
+// BuildIDPOptions encapsulates the options for the udo catalog list idp command
 type BuildIDPOptions struct {
 	// list of build options
 	buildTaskType       string
@@ -217,7 +217,7 @@ func (o *BuildIDPOptions) Run() (err error) {
 	return
 }
 
-// NewCmdBuild implements the kdo catalog list idps command
+// NewCmdBuild implements the udo catalog list idps command
 func NewCmdBuild(name, fullName string) *cobra.Command {
 	o := NewBuildIDPOptions()
 

--- a/pkg/kdo/cli/version/version.go
+++ b/pkg/kdo/cli/version/version.go
@@ -64,7 +64,7 @@ func (o *VersionOptions) Run() (err error) {
 		}
 	}
 
-	fmt.Println("kdo " + VERSION + " (" + GITCOMMIT + ")")
+	fmt.Println("udo " + VERSION + " (" + GITCOMMIT + ")")
 
 	return
 }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Renames the cli from `kdo` to `udo`. Keeps the kdo package as-is, however.

## Was the change discussed in an issue?
fixes #???
N/A

## How to test changes?
<!-- Please describe the steps to test the PR -->
