### PR TITLE
Add Reusable Build Container logic for IDP Builds

### DIFF
--- a/pkg/build/deploy.go
+++ b/pkg/build/deploy.go
@@ -156,7 +156,7 @@ func (b *BuildTask) setPFEEnvVars() []corev1.EnvVar {
 		},
 	}
 
-	if b.Kind == ReusableBuildContainer {
+	if b.Kind == string(ReusableBuildContainer) {
 		envVars = []corev1.EnvVar{}
 	}
 
@@ -184,7 +184,7 @@ func (b *BuildTask) generateDeployment(volumes []corev1.Volume, volumeMounts []c
 			Env:          envVars,
 		},
 	}
-	if b.Kind == ReusableBuildContainer {
+	if b.Kind == string(ReusableBuildContainer) {
 		container = []corev1.Container{
 			{
 				Name:            containerName,
@@ -263,7 +263,7 @@ func (b *BuildTask) generateService() corev1.Service {
 		},
 	}
 
-	if b.Kind == ReusableBuildContainer {
+	if b.Kind == string(ReusableBuildContainer) {
 		ports = []corev1.ServicePort{
 			{
 				Port: int32(port1),

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -13,10 +13,10 @@ func CreateBuildTaskKubeJob(buildTaskJobName string, buildTaskType string, names
 	fmt.Printf("Creating job %s\n", buildTaskJobName)
 	// Create a Kube job to run mvn package for a Liberty project
 	command := []string{"/bin/sh", "-c"}
-	commandArgs := []string{FullBuildTask}
+	commandArgs := []string{string(FullBuildTask)}
 
-	if buildTaskType == "inc" {
-		commandArgs = []string{IncrementalBuildTask}
+	if buildTaskType == string(Incremental) {
+		commandArgs = []string{string(IncrementalBuildTask)}
 	}
 
 	fmt.Printf("Command: %s %s\n", command, commandArgs)

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -3,8 +3,6 @@ package build
 import (
 	"fmt"
 
-	"github.com/redhat-developer/odo-fork/pkg/component"
-	"github.com/redhat-developer/odo-fork/pkg/kclient"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,19 +65,4 @@ func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace stri
 	}
 
 	return job, nil
-}
-
-//DeployReusableBuildContainer deploy a reusable build container
-func DeployReusableBuildContainer(client *kclient.Client, imageName string) {
-
-	storageToBeMounted := make(map[string]*corev1.PersistentVolumeClaim)
-
-	createArgs := kclient.CreateArgs{
-		Name:               "reusable-build-container",
-		ImageName:          imageName,
-		ApplicationName:    "reusable-build-container",
-		StorageToBeMounted: storageToBeMounted,
-	}
-
-	component.CreateFromPath(client, createArgs)
 }

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -3,6 +3,8 @@ package build
 import (
 	"fmt"
 
+	"github.com/redhat-developer/odo-fork/pkg/component"
+	"github.com/redhat-developer/odo-fork/pkg/kclient"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,4 +67,19 @@ func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace stri
 	}
 
 	return job, nil
+}
+
+//DeployReusableBuildContainer deploy a reusable build container
+func DeployReusableBuildContainer(client *kclient.Client, imageName string) {
+
+	storageToBeMounted := make(map[string]*corev1.PersistentVolumeClaim)
+
+	createArgs := kclient.CreateArgs{
+		Name:               "reusable-build-container",
+		ImageName:          imageName,
+		ApplicationName:    "reusable-build-container",
+		StorageToBeMounted: storageToBeMounted,
+	}
+
+	component.CreateFromPath(client, createArgs)
 }

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -9,13 +9,13 @@ import (
 )
 
 // CreateBuildTaskKubeJob creates a Kubernetes Job
-func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace string, idpClaimName string, projectSubPath string, projectName string) (*batchv1.Job, error) {
-	fmt.Printf("Creating job %s\n", buildTaskJob)
+func CreateBuildTaskKubeJob(buildTaskJobName string, buildTaskType string, namespace string, idpClaimName string, projectSubPath string, projectName string) (*batchv1.Job, error) {
+	fmt.Printf("Creating job %s\n", buildTaskJobName)
 	// Create a Kube job to run mvn package for a Liberty project
 	command := []string{"/bin/sh", "-c"}
 	commandArgs := []string{"/data/idp/bin/build-container-full.sh"}
 
-	if taskName == "inc" {
+	if buildTaskType == "inc" {
 		commandArgs = []string{"/data/idp/bin/build-container-update.sh"}
 	}
 
@@ -24,7 +24,7 @@ func CreateBuildTaskKubeJob(buildTaskJob string, taskName string, namespace stri
 	parallelism := int32(1)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      buildTaskJob,
+			Name:      buildTaskJobName,
 			Namespace: namespace,
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/build/job.go
+++ b/pkg/build/job.go
@@ -13,10 +13,10 @@ func CreateBuildTaskKubeJob(buildTaskJobName string, buildTaskType string, names
 	fmt.Printf("Creating job %s\n", buildTaskJobName)
 	// Create a Kube job to run mvn package for a Liberty project
 	command := []string{"/bin/sh", "-c"}
-	commandArgs := []string{"/data/idp/bin/build-container-full.sh"}
+	commandArgs := []string{FullBuildTask}
 
 	if buildTaskType == "inc" {
-		commandArgs = []string{"/data/idp/bin/build-container-update.sh"}
+		commandArgs = []string{IncrementalBuildTask}
 	}
 
 	fmt.Printf("Command: %s %s\n", command, commandArgs)

--- a/pkg/build/utils.go
+++ b/pkg/build/utils.go
@@ -1,16 +1,29 @@
 package build
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	// Build Task Types
+
+	// FullBuildTask is the IDP full build task script path in the Persistent Volume
+	FullBuildTask = "/data/idp/bin/build-container-full.sh"
+	// IncrementalBuildTask is the IDP incremental build task script path in the Persistent Volume
+	IncrementalBuildTask = "/data/idp/bin/build-container-update.sh"
+
+	// Build Task Struct Kind
+
+	// ReusableBuildContainer is a Build Task Kind where udo will reuse the build container to build projects
+	ReusableBuildContainer string = "ReusableBuildContainer"
+	// KubeJob is a Build Task Kind where udo will kick off a Kube job to build projects
+	KubeJob string = "KubeJob"
+	// Component is a Build Task Kind where udo will deploy a component
+	Component string = "Component"
 )
 
 // GetIDPPVC retrieves the PVC (Persistent Volume Claim) associated with the Iterative Development Pack
@@ -32,59 +45,4 @@ func GetIDPPVC(client *kclient.Client, namespace string, labels string) string {
 	}
 
 	return pvcName
-}
-
-// ExecPodCmd executes command in the pod container
-func ExecPodCmd(client *kclient.Client, command []string, containerName, podName, namespace string) (string, string, error) {
-
-	fmt.Printf("Executing command: %s in pod: %s container: %s\n", strings.Join(command, " "), podName, containerName)
-
-	clientset := client.KubeClient
-	config := client.KubeClientConfig
-
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec")
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-
-	parameterCodec := runtime.NewParameterCodec(scheme)
-	req.VersionedParams(&corev1.PodExecOptions{
-		Command:   command,
-		Container: containerName,
-		Stdin:     false,
-		Stdout:    true,
-		Stderr:    true,
-		TTY:       false,
-	}, parameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	if err != nil {
-		panic(err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  nil,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	return stdout.String(), stderr.String(), nil
-}
-
-// ListPods list the pods using the selector
-func ListPods(client *kclient.Client, namespace string, listOptions metav1.ListOptions) (*corev1.PodList, error) {
-	clientset := client.KubeClient
-	podList, err := clientset.CoreV1().Pods(namespace).List(listOptions)
-
-	return podList, err
 }

--- a/pkg/build/utils.go
+++ b/pkg/build/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,8 @@ func GetIDPPVC(client *kclient.Client, namespace string, labels string) string {
 
 // ExecPodCmd executes command in the pod container
 func ExecPodCmd(client *kclient.Client, command []string, containerName, podName, namespace string) (string, string, error) {
+
+	fmt.Printf("Executing command: %s in pod: %s container: %s\n", strings.Join(command, " "), podName, containerName)
 
 	clientset := client.KubeClient
 	config := client.KubeClientConfig
@@ -78,4 +81,12 @@ func ExecPodCmd(client *kclient.Client, command []string, containerName, podName
 	}
 
 	return stdout.String(), stderr.String(), nil
+}
+
+// ListPods list the pods using the selector
+func ListPods(client *kclient.Client, namespace string, listOptions metav1.ListOptions) (*corev1.PodList, error) {
+	clientset := client.KubeClient
+	podList, err := clientset.CoreV1().Pods(namespace).List(listOptions)
+
+	return podList, err
 }

--- a/pkg/build/utils.go
+++ b/pkg/build/utils.go
@@ -62,8 +62,6 @@ func ExecPodCmd(client *kclient.Client, command []string, containerName, podName
 		TTY:       false,
 	}, parameterCodec)
 
-	fmt.Println("Request URL:", req.URL().String())
-
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
 		panic(err)

--- a/pkg/build/utils.go
+++ b/pkg/build/utils.go
@@ -8,22 +8,32 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// BuildTaskType is of type string which indiciates the type of build task
+type BuildTaskType string
+
+// BuildTaskScript is of type string which indicates the script path for the build task
+type BuildTaskScript string
+
+// BuildTaskKind is of type string which indicates the kind of build task
+type BuildTaskKind string
+
 const (
-	// Build Task Types
+	// Incremental is of type BuildTaskType which indicates it is an incremental build
+	Incremental BuildTaskType = "inc"
+	// Full is of type BuildTaskType which indicates it is a full build
+	Full BuildTaskType = "full"
 
 	// FullBuildTask is the IDP full build task script path in the Persistent Volume
-	FullBuildTask = "/data/idp/bin/build-container-full.sh"
+	FullBuildTask BuildTaskScript = "/data/idp/bin/build-container-full.sh"
 	// IncrementalBuildTask is the IDP incremental build task script path in the Persistent Volume
-	IncrementalBuildTask = "/data/idp/bin/build-container-update.sh"
+	IncrementalBuildTask BuildTaskScript = "/data/idp/bin/build-container-update.sh"
 
-	// Build Task Struct Kind
-
-	// ReusableBuildContainer is a Build Task Kind where udo will reuse the build container to build projects
-	ReusableBuildContainer string = "ReusableBuildContainer"
-	// KubeJob is a Build Task Kind where udo will kick off a Kube job to build projects
-	KubeJob string = "KubeJob"
-	// Component is a Build Task Kind where udo will deploy a component
-	Component string = "Component"
+	// ReusableBuildContainer is a BuildTaskKind where udo will reuse the build container to build projects
+	ReusableBuildContainer BuildTaskKind = "ReusableBuildContainer"
+	// KubeJob is a BuildTaskKind where udo will kick off a Kube job to build projects
+	KubeJob BuildTaskKind = "KubeJob"
+	// Component is a BuildTaskKind where udo will deploy a component
+	Component BuildTaskKind = "Component"
 )
 
 // GetIDPPVC retrieves the PVC (Persistent Volume Claim) associated with the Iterative Development Pack

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -270,7 +270,10 @@ func CreateFromPath(client *kclient.Client, params kclient.CreateArgs) error {
 		}
 
 		podSelector := fmt.Sprintf("deployment=%s", selectorLabels)
-		_, err = client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
+		watchOptions := metav1.ListOptions{
+			LabelSelector: podSelector,
+		}
+		_, err = client.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start")
 		if err != nil {
 			return err
 		}
@@ -676,9 +679,12 @@ func PushLocal(client *kclient.Client, componentName string, applicationName str
 	}
 	// Find Pod for component
 	podSelector := fmt.Sprintf("deployment=%s", dep.Name)
+	watchOptions := metav1.ListOptions{
+		LabelSelector: podSelector,
+	}
 
 	// Wait for Pod to be in running state otherwise we can't sync data to it.
-	pod, err := client.WaitAndGetPod(podSelector, corev1.PodRunning, "Waiting for component to start")
+	pod, err := client.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start")
 	if err != nil {
 		return errors.Wrapf(err, "error while waiting for pod  %s", podSelector)
 	}

--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -591,14 +591,14 @@ func (c *Client) WaitAndGetPod(watchOptions metav1.ListOptions, desiredPhase cor
 
 // GetPodLogs streams the specified pod's logs to the specified output stream
 func (c *Client) GetPodLogs(pod *corev1.Pod, file *os.File) (err error) {
-	fmt.Printf("Retrieving job logs for pod: %s\n\n", pod.Name)
+	glog.V(4).Infof("Retrieving job logs for pod: %s\n\n", pod.Name)
 	req := c.KubeClient.CoreV1().Pods(c.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Follow: true,
 	})
 	readCloser, err := req.Stream()
 	defer readCloser.Close()
 	if err != nil {
-		fmt.Printf("Unable to retrieve job logs for pod: %s\n", pod.Name)
+		glog.V(4).Infof("Unable to retrieve job logs for pod: %s\n", pod.Name)
 		return
 	}
 
@@ -609,7 +609,7 @@ func (c *Client) GetPodLogs(pod *corev1.Pod, file *os.File) (err error) {
 // ExecPodCmd executes command in the pod container
 func (c *Client) ExecPodCmd(command []string, containerName, podName string) (string, string, error) {
 
-	fmt.Printf("Executing command: %s in pod: %s container: %s\n", strings.Join(command, " "), podName, containerName)
+	glog.V(0).Infof("Executing command: %s in pod: %s container: %s\n", strings.Join(command, " "), podName, containerName)
 
 	clientset := c.KubeClient
 	config := c.KubeClientConfig
@@ -637,7 +637,7 @@ func (c *Client) ExecPodCmd(command []string, containerName, podName string) (st
 
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
-		panic(err)
+		return "", "", err
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -648,7 +648,7 @@ func (c *Client) ExecPodCmd(command []string, containerName, podName string) (st
 		Tty:    false,
 	})
 	if err != nil {
-		panic(err)
+		return "", "", err
 	}
 
 	return stdout.String(), stderr.String(), nil

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -53,7 +53,7 @@ func (o *BuildIDPOptions) Complete(name string, cmd *cobra.Command, args []strin
 
 // Validate validates the BuildIDPOptions based on completed values
 func (o *BuildIDPOptions) Validate() (err error) {
-	if o.buildTaskType != "full" && o.buildTaskType != "inc" {
+	if o.buildTaskType != string(build.Full) && o.buildTaskType != string(build.Incremental) {
 		return fmt.Errorf("The first option should be either full or inc")
 	}
 	return
@@ -77,7 +77,7 @@ func (o *BuildIDPOptions) Run() (err error) {
 
 		// Create the Reusable Build Container deployment object
 		ReusableBuildContainerInstance := build.BuildTask{
-			Kind:               build.ReusableBuildContainer,
+			Kind:               string(build.ReusableBuildContainer),
 			Name:               strings.ToLower(o.projectName) + "-reusable-build-container",
 			Image:              "docker.io/maven:3.6",
 			ContainerName:      "maven-build",
@@ -149,9 +149,9 @@ func (o *BuildIDPOptions) Run() (err error) {
 		fmt.Printf("The Reusable Build Container Pod Name: %s\n", ReusableBuildContainerInstance.PodName)
 
 		// Execute the Mvm command in the Build Container
-		command := []string{"/bin/sh", "-c", build.FullBuildTask}
-		if o.buildTaskType == "inc" {
-			command = []string{"/bin/sh", "-c", build.IncrementalBuildTask}
+		command := []string{"/bin/sh", "-c", string(build.FullBuildTask)}
+		if o.buildTaskType == string(build.Incremental) {
+			command = []string{"/bin/sh", "-c", string(build.IncrementalBuildTask)}
 		}
 		// command := []string{"/bin/sh", "-c", "hostname", "-f"}
 		output, stderr, err := o.Context.Client.ExecPodCmd(command, ReusableBuildContainerInstance.ContainerName, ReusableBuildContainerInstance.PodName)
@@ -248,13 +248,13 @@ func (o *BuildIDPOptions) Run() (err error) {
 		}
 	}
 
-	if o.buildTaskType == "full" {
+	if o.buildTaskType == string(build.Full) {
 		// Deploy the application if it is a full build type
 		fmt.Println("Deploying application on a full build")
 
 		// Create the Codewind deployment object
 		BuildTaskInstance := build.BuildTask{
-			Kind:               build.Component,
+			Kind:               string(build.Component),
 			Name:               "cw-maysunliberty2-6c1b1ce0-cb4c-11e9-be96",
 			Image:              "websphere-liberty:19.0.0.3-webProfile7",
 			ContainerName:      "libertyproject",

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -12,9 +12,6 @@ import (
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildRecommendedCommandName is the recommended catalog command name
@@ -66,7 +63,7 @@ func (o *BuildIDPOptions) Validate() (err error) {
 
 // Run contains the logic for the command associated with ListIDPOptions
 func (o *BuildIDPOptions) Run() (err error) {
-	clientset := o.Context.Client.KubeClient
+	// clientset := o.Context.Client.KubeClient
 	namespace := o.Context.Client.Namespace
 
 	fmt.Printf("Namespace: %s\n", namespace)
@@ -79,6 +76,7 @@ func (o *BuildIDPOptions) Run() (err error) {
 
 	if o.reuseBuildContainer == true {
 		fmt.Println("Reusing the build container")
+		build.DeployReusableBuildContainer(o.Context.Client, "docker.io/maven:3.6")
 	}
 
 	buildTaskJobName := "codewind-liberty-build-job"

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -3,7 +3,6 @@ package component
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -48,11 +47,7 @@ func (o *BuildIDPOptions) Complete(name string, cmd *cobra.Command, args []strin
 	o.Context = genericclioptions.NewContext(cmd)
 	o.buildTaskType = args[0]
 	o.projectName = args[1]
-	reuseBuildContainer, err := strconv.ParseBool(args[2])
-	if err != nil {
-		return fmt.Errorf("The third option for reusing the build container should be either true or false")
-	}
-	o.reuseBuildContainer = reuseBuildContainer
+	fmt.Println("reuseBuildContainer flag: ", o.reuseBuildContainer)
 	return
 }
 
@@ -314,11 +309,13 @@ func NewCmdBuild(name, fullName string) *cobra.Command {
 		Short:   "Start a IDP Build",
 		Long:    "Start a IDP Build using the Build Tasks.",
 		Example: fmt.Sprintf(buildCmdExample, fullName),
-		Args:    cobra.ExactArgs(3),
+		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+
+	buildCmd.Flags().BoolVar(&o.reuseBuildContainer, "reuseBuildContainer", false, "Re-use Build Container for IDP Builds")
 
 	return buildCmd
 }

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -176,7 +176,11 @@ func (o *BuildIDPOptions) Run() (err error) {
 		fmt.Printf("The Resuable Build Container Pod Name: %s\n", ReusableBuildContainerInstance.PodName)
 
 		// Execute the Mvm command in the Build Container
-		command := []string{"/bin/sh", "-c", "hostname", "-f"}
+		command := []string{"/bin/sh", "-c", "/data/idp/bin/build-container-full.sh"}
+		if o.buildTaskType == "inc" {
+			command = []string{"/bin/sh", "-c", "/data/idp/bin/build-container-update.sh"}
+		}
+		// command := []string{"/bin/sh", "-c", "hostname", "-f"}
 		output, stderr, err := build.ExecPodCmd(o.Context.Client, command, ReusableBuildContainerInstance.ContainerName, ReusableBuildContainerInstance.PodName, namespace)
 		if len(stderr) != 0 {
 			fmt.Println("Resuable Build Container STDERR:", stderr)

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -1,8 +1,8 @@
 package component
 
 import (
-	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +12,9 @@ import (
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildRecommendedCommandName is the recommended catalog command name
@@ -34,7 +37,7 @@ type BuildIDPOptions struct {
 	*genericclioptions.Context
 }
 
-// NewBuildIDPOptions creates a new ListIDPOptions instance
+// NewBuildIDPOptions creates a new BuildIDPOptions instance
 func NewBuildIDPOptions() *BuildIDPOptions {
 	return &BuildIDPOptions{}
 }
@@ -53,7 +56,7 @@ func (o *BuildIDPOptions) Complete(name string, cmd *cobra.Command, args []strin
 	return
 }
 
-// Validate validates the ListIDPOptions based on completed values
+// Validate validates the BuildIDPOptions based on completed values
 func (o *BuildIDPOptions) Validate() (err error) {
 	if o.buildTaskType != "full" && o.buildTaskType != "inc" {
 		return fmt.Errorf("The first option should be either full or inc")
@@ -61,9 +64,9 @@ func (o *BuildIDPOptions) Validate() (err error) {
 	return
 }
 
-// Run contains the logic for the command associated with ListIDPOptions
+// Run contains the logic for the command associated with BuildIDPOptions
 func (o *BuildIDPOptions) Run() (err error) {
-	// clientset := o.Context.Client.KubeClient
+	clientset := o.Context.Client.KubeClient
 	namespace := o.Context.Client.Namespace
 
 	fmt.Printf("Namespace: %s\n", namespace)
@@ -75,101 +78,221 @@ func (o *BuildIDPOptions) Run() (err error) {
 	fmt.Printf("Service Account: %s\n", serviceAccountName)
 
 	if o.reuseBuildContainer == true {
-		fmt.Println("Reusing the build container")
-		build.DeployReusableBuildContainer(o.Context.Client, "docker.io/maven:3.6")
-	}
+		// Create a Build Container for re-use
+		fmt.Println("Reusing the build container...")
+		// Create the Reusable Build Container deployment object
+		ReusableBuildContainerInstance := build.BuildTask{
+			Type:               "build",
+			Name:               strings.ToLower(o.projectName) + "-reusable-build-container",
+			Image:              "docker.io/maven:3.6",
+			ContainerName:      "maven-build",
+			Namespace:          namespace,
+			PVCName:            idpClaimName,
+			ServiceAccountName: serviceAccountName,
+			// OwnerReferenceName: ownerReferenceName,
+			// OwnerReferenceUID:  ownerReferenceUID,
+			Privileged: true,
+			MountPath:  "/data/idp/",
+			SubPath:    "projects/" + o.projectName,
+		}
+		labels := map[string]string{
+			"app": ReusableBuildContainerInstance.Name,
+		}
 
-	buildTaskJobName := "codewind-liberty-build-job"
+		reusableBuildContainerDeploy := build.CreateComponentDeploy(ReusableBuildContainerInstance, o.projectName, labels)
+		reusableBuildContainerService := build.CreateComponentService(ReusableBuildContainerInstance, labels)
 
-	job, err := build.CreateBuildTaskKubeJob(buildTaskJobName, o.buildTaskType, namespace, idpClaimName, "projects/"+o.projectName, o.projectName)
-	if err != nil {
-		fmt.Println("There was a problem with the job configuration, exiting...")
-		panic(err.Error())
-	}
-
-	kubeJob, err := clientset.BatchV1().Jobs(namespace).Create(job)
-	if err != nil {
-		fmt.Println("Failed to create a job, exiting...")
-		panic(err.Error())
-	}
-
-	fmt.Printf("The job %s has been created\n", kubeJob.Name)
-
-	// Wait for pods to start running so that we can tail the logs
-	po, err := o.Context.Client.WaitAndGetPod("job-name=codewind-liberty-build-job", corev1.PodRunning, "Waiting for the build job to run")
-	if err != nil {
-		err = errors.New("The build job failed to run")
-		return
-	}
-
-	err = o.Context.Client.GetPodLogs(po, os.Stdout)
-	if err != nil {
-		err = errors.New("Failed to get the logs for the build job")
-		return
-	}
-
-	// TODO-KDO: Set owner references
-	var jobSucceeded bool
-	// Loop and see if the job either succeeded or failed
-	loop := true
-	for loop == true {
-		jobs, err := clientset.BatchV1().Jobs(namespace).List(metav1.ListOptions{})
+		fmt.Println("===============================")
+		fmt.Println("Deploying reusable build container...")
+		_, err = clientset.CoreV1().Services(namespace).Create(&reusableBuildContainerService)
 		if err != nil {
+			fmt.Printf("Unable to create application service: %v\n", err)
+			os.Exit(1)
+		} else {
+			fmt.Println("The service has been created.")
+		}
+		_, err = clientset.AppsV1().Deployments(namespace).Create(&reusableBuildContainerDeploy)
+		if err != nil {
+			fmt.Printf("Unable to create application deployment: %v\n", err)
+			os.Exit(1)
+		} else {
+			fmt.Println("The deployment has been created.")
+		}
+		fmt.Println("===============================")
+
+		// Wait for pods to start running so that we can tail the logs
+		fmt.Printf("Waiting for pod to run\n")
+		foundRunningPod := false
+		// reusableBuildContainerPodName := ""
+		for foundRunningPod == false {
+			listOptions := metav1.ListOptions{
+				LabelSelector: "app=proja-reusable-build-container",
+				FieldSelector: "status.phase=Running",
+			}
+			podList, err := build.ListPods(o.Context.Client, namespace, listOptions)
+
+			if err != nil {
+				continue
+			}
+
+			for _, pod := range podList.Items {
+				fmt.Printf("Running pod found: %s...\n\n", pod.Name)
+				ReusableBuildContainerInstance.PodName = pod.Name
+				foundRunningPod = true
+			}
+		}
+		fmt.Printf("The Resuable Build Container Pod Name: %s\n", ReusableBuildContainerInstance.PodName)
+
+		// Execute the Mvm command in the Build Container
+		command := []string{"/bin/sh", "-c", "hostname", "-f"}
+		output, stderr, err := build.ExecPodCmd(o.Context.Client, command, ReusableBuildContainerInstance.ContainerName, ReusableBuildContainerInstance.PodName, namespace)
+		if len(stderr) != 0 {
+			fmt.Println("Resuable Build Container STDERR:", stderr)
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Printf("Error occured while executing command %s in the pod %s: %s\n", strings.Join(command, " "), ReusableBuildContainerInstance.PodName, err)
+			os.Exit(1)
+		} else {
+			fmt.Printf("Reusable Build Container Output: \n%s\n", output)
+		}
+	} else {
+		// Create a Kube Job for building
+		fmt.Println("Creating a Kube Job for building...")
+
+		buildTaskJobName := "codewind-liberty-build-job"
+
+		job, err := build.CreateBuildTaskKubeJob(buildTaskJobName, o.buildTaskType, namespace, idpClaimName, "projects/"+o.projectName, o.projectName)
+		if err != nil {
+			fmt.Println("There was a problem with the job configuration, exiting...")
 			panic(err.Error())
 		}
-		for _, job := range jobs.Items {
-			if strings.Contains(job.Name, buildTaskJobName) {
-				succeeded := job.Status.Succeeded
-				failed := job.Status.Failed
-				if succeeded == 1 {
-					fmt.Printf("The job %s succeeded\n", job.Name)
-					jobSucceeded = true
-					loop = false
-				} else if failed > 0 {
-					fmt.Printf("The job %s failed\n", job.Name)
-					jobSucceeded = false
-					loop = false
+
+		kubeJob, err := clientset.BatchV1().Jobs(namespace).Create(job)
+		if err != nil {
+			fmt.Println("Failed to create a job, exiting...")
+			panic(err.Error())
+		}
+
+		fmt.Printf("The job %s has been created\n", kubeJob.Name)
+
+		// Wait for pods to start running so that we can tail the logs
+		fmt.Printf("Waiting for pod to run\n")
+		foundRunningPod := false
+		for foundRunningPod == false {
+			listOptions := metav1.ListOptions{
+				LabelSelector: "job-name=codewind-liberty-build-job",
+				FieldSelector: "status.phase=Running",
+			}
+			podList, err := build.ListPods(o.Context.Client, namespace, listOptions)
+
+			if err != nil {
+				continue
+			}
+
+			for _, pod := range podList.Items {
+				fmt.Printf("Running pod found: %s Retrieving logs...\n\n", pod.Name)
+				foundRunningPod = true
+			}
+		}
+
+		// Print logs before deleting the job
+		listOptions := metav1.ListOptions{
+			LabelSelector: "job-name=codewind-liberty-build-job",
+		}
+		podList, err := build.ListPods(o.Context.Client, namespace, listOptions)
+
+		for _, pod := range podList.Items {
+			fmt.Printf("Retrieving logs for pod: %s\n\n", pod.Name)
+			req := clientset.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Follow: true,
+			})
+			readCloser, err := req.Stream()
+			if err != nil {
+				fmt.Printf("Unable to retrieve logs for pod: %s\n", pod.Name)
+				continue
+			}
+
+			defer readCloser.Close()
+			_, err = io.Copy(os.Stdout, readCloser)
+		}
+
+		// TODO: Set owner references
+		var jobSucceeded bool
+		// Loop and see if the job either succeeded or failed
+		loop := true
+		for loop == true {
+			jobs, err := clientset.BatchV1().Jobs(namespace).List(metav1.ListOptions{})
+			if err != nil {
+				panic(err.Error())
+			}
+			for _, job := range jobs.Items {
+				if strings.Contains(job.Name, buildTaskJobName) {
+					succeeded := job.Status.Succeeded
+					failed := job.Status.Failed
+					if succeeded == 1 {
+						fmt.Printf("The job %s succeeded\n", job.Name)
+						jobSucceeded = true
+						loop = false
+					} else if failed > 0 {
+						fmt.Printf("The job %s failed\n", job.Name)
+						jobSucceeded = false
+						loop = false
+					}
 				}
 			}
 		}
-	}
 
-	if loop == false {
-		// delete the job
-		gracePeriodSeconds := int64(0)
-		deletionPolicy := metav1.DeletePropagationForeground
-		err := clientset.BatchV1().Jobs(namespace).Delete(buildTaskJobName, &metav1.DeleteOptions{
-			PropagationPolicy:  &deletionPolicy,
-			GracePeriodSeconds: &gracePeriodSeconds,
-		})
-		if err != nil {
-			panic(err.Error())
-		} else {
-			fmt.Printf("The job %s has been deleted\n", buildTaskJobName)
+		if loop == false {
+			// delete the job
+			gracePeriodSeconds := int64(0)
+			deletionPolicy := metav1.DeletePropagationForeground
+			err := clientset.BatchV1().Jobs(namespace).Delete(buildTaskJobName, &metav1.DeleteOptions{
+				PropagationPolicy:  &deletionPolicy,
+				GracePeriodSeconds: &gracePeriodSeconds,
+			})
+			if err != nil {
+				panic(err.Error())
+			} else {
+				fmt.Printf("The job %s has been deleted\n", buildTaskJobName)
+			}
+		}
+
+		if !jobSucceeded {
+			fmt.Println("The job failed, exiting...")
+			os.Exit(1)
 		}
 	}
 
-	if !jobSucceeded {
-		fmt.Println("The job failed, exiting...")
-		os.Exit(1)
-	}
-
-	// Create the Codewind deployment object
-	BuildTaskInstance := build.BuildTask{
-		Name:               "cw-maysunliberty2-6c1b1ce0-cb4c-11e9-be96",
-		Image:              "websphere-liberty:19.0.0.3-webProfile7",
-		Namespace:          namespace,
-		PVCName:            idpClaimName,
-		ServiceAccountName: serviceAccountName,
-		// OwnerReferenceName: ownerReferenceName,
-		// OwnerReferenceUID:  ownerReferenceUID,
-		Privileged: true,
-	}
-
 	if o.buildTaskType == "full" {
+		// Deploy the application if it is a full build type
+		fmt.Println("Deploying application on a full build")
+
+		// Create the Codewind deployment object
+		BuildTaskInstance := build.BuildTask{
+			Type:               "component",
+			Name:               "cw-maysunliberty2-6c1b1ce0-cb4c-11e9-be96",
+			Image:              "websphere-liberty:19.0.0.3-webProfile7",
+			ContainerName:      "libertyproject",
+			Namespace:          namespace,
+			PVCName:            idpClaimName,
+			ServiceAccountName: serviceAccountName,
+			// OwnerReferenceName: ownerReferenceName,
+			// OwnerReferenceUID:  ownerReferenceUID,
+			Privileged: true,
+			MountPath:  "/config",
+			SubPath:    "projects/" + o.projectName + "/buildartifacts/",
+		}
+
+		labels := map[string]string{
+			"app":     "javamicroprofiletemplate-selector",
+			"chart":   "javamicroprofiletemplate-1.0.0",
+			"release": BuildTaskInstance.Name,
+		}
+
 		// Deploy Application
-		deploy := build.CreateComponentDeploy(BuildTaskInstance, o.projectName)
-		service := build.CreateComponentService(BuildTaskInstance)
+		deploy := build.CreateComponentDeploy(BuildTaskInstance, o.projectName, labels)
+		service := build.CreateComponentService(BuildTaskInstance, labels)
 
 		fmt.Println("===============================")
 		fmt.Println("Deploying application...")
@@ -177,12 +300,17 @@ func (o *BuildIDPOptions) Run() (err error) {
 		if err != nil {
 			fmt.Printf("Unable to create application service: %v\n", err)
 			os.Exit(1)
+		} else {
+			fmt.Println("The service has been created.")
 		}
 		_, err = clientset.AppsV1().Deployments(namespace).Create(&deploy)
 		if err != nil {
 			fmt.Printf("Unable to create application deployment: %v\n", err)
 			os.Exit(1)
+		} else {
+			fmt.Println("The deployment has been created.")
 		}
+		fmt.Println("===============================")
 	}
 
 	return

--- a/pkg/kdo/cli/component/build.go
+++ b/pkg/kdo/cli/component/build.go
@@ -184,7 +184,6 @@ func (o *BuildIDPOptions) Run() (err error) {
 		output, stderr, err := build.ExecPodCmd(o.Context.Client, command, ReusableBuildContainerInstance.ContainerName, ReusableBuildContainerInstance.PodName, namespace)
 		if len(stderr) != 0 {
 			fmt.Println("Resuable Build Container STDERR:", stderr)
-			os.Exit(1)
 		}
 		if err != nil {
 			fmt.Printf("Error occured while executing command %s in the pod %s: %s\n", strings.Join(command, " "), ReusableBuildContainerInstance.PodName, err)
@@ -192,6 +191,8 @@ func (o *BuildIDPOptions) Run() (err error) {
 		} else {
 			fmt.Printf("Reusable Build Container Output: \n%s\n", output)
 		}
+
+		fmt.Println("Finished executing the IDP Build Task in the Resuable Build Container...")
 	} else {
 		// Create a Kube Job for building
 		fmt.Println("Creating a Kube Job for building...")


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
This PR adds in the reusable build container option logic for `kdo build` along with Kube job.

## Was the change discussed in an issue?
{internal}
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->
`kdo build <build task type> <project name> <reuse build container flag>`

Reuse the Build Container:
```
./udo build inc projA --reuseBuildContainer
Build arguments: inc projA
reuseBuildContainer flag:  true
Namespace: eclipse-che
Persistent Volume Claim: idp-data-volume
Service Account: default
Checking if Reusable Build Container has already been deployed...
 ✓  Checking to see if a Reusable Container is up... [58ms]
Running pod found: proja-reusable-build-container-7c7959d689-9lspm...
```

Use the Kube Job:
```
./udo build inc projA
Build arguments: inc projA
reuseBuildContainer flag:  false
Namespace: eclipse-che
Persistent Volume Claim: idp-data-volume
Service Account: default
Creating a Kube Job for building...
Creating job codewind-liberty-build-job
Command: [/bin/sh -c] [/data/idp/bin/build-container-update.sh]
The job codewind-liberty-build-job has been created
 ✓  Waiting for the build job to run [4s]
Retrieving job logs for pod: codewind-liberty-build-job-5rqn4
```

