### PR TITLE
Fix waiting for pod logic

### DIFF
--- a/pkg/kclient/kclient.go
+++ b/pkg/kclient/kclient.go
@@ -589,6 +589,23 @@ func (c *Client) WaitAndGetPod(selector string, desiredPhase corev1.PodPhase, wa
 	}
 }
 
+// GetPodLogs streams the specified pod's logs to the specified output stream
+func (c *Client) GetPodLogs(pod *corev1.Pod, file *os.File) (err error) {
+	fmt.Printf("Retrieving job logs for pod: %s\n\n", pod.Name)
+	req := c.KubeClient.CoreV1().Pods(c.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Follow: true,
+	})
+	readCloser, err := req.Stream()
+	defer readCloser.Close()
+	if err != nil {
+		fmt.Printf("Unable to retrieve job logs for pod: %s\n", pod.Name)
+		return
+	}
+
+	_, err = io.Copy(file, readCloser)
+	return err
+}
+
 // WaitAndGetSecret blocks and waits until the secret is available
 func (c *Client) WaitAndGetSecret(name string, namespace string) (*corev1.Secret, error) {
 	glog.V(4).Infof("Waiting for secret %s to become available", name)


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->

The waiting for pod logic would wait endlessly if there was a problem with the Job.

## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->

## How to test changes?
<!-- Please describe the steps to test the PR -->

1. Add an `exit 1` to the beginning of the build-container-full.sh script in `/data/idp/bin` of the IDP volume

Example:
```
#!/bin/sh
exit 1

date
echo Started - Full build using container folders
```

Example output:
```
> udo build full projA false
Build arguments: full projA false
Namespace: default
Persistent Volume Claim: idp-data-volume
Service Account: default
Creating job codewind-liberty-build-job
Command: [/bin/sh -c] [/data/idp/bin/build-container-full.sh]
The job codewind-liberty-build-job has been created
 ✗  Waiting for the build job to run [3s]
 ✗  The build job failed to run
```