### PR TITLE
Support local IDP repos

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -26,10 +26,18 @@ type CatalogEntry struct {
 }
 
 // List lists all the available Iterative-Dev Packs
-func List() ([]CatalogEntry, error) {
-	// See if we have an index.json already cached
+func List(localIndexJSON string) ([]CatalogEntry, error) {
+
 	var idpList []CatalogEntry
-	indexJSONFile := path.Join(os.TempDir(), ".udo", "index.json")
+
+	// If a local index.json file wasn't passed in, see if one is cached
+	var indexJSONFile string
+	if localIndexJSON == "" {
+		indexJSONFile = path.Join(os.TempDir(), ".udo", "index.json")
+	} else {
+		indexJSONFile = localIndexJSON
+	}
+
 	// Load the index.json file into memory
 	var jsonBytes []byte
 	if _, err := os.Stat(indexJSONFile); os.IsNotExist(err) {
@@ -53,9 +61,9 @@ func List() ([]CatalogEntry, error) {
 }
 
 // Search searches for the IDP in the catalog
-func Search(name string) ([]string, error) {
+func Search(name string, localIndexJSON string) ([]string, error) {
 	var result []string
-	idpList, err := List()
+	idpList, err := List(localIndexJSON)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list Iterative-Dev Packs")
 	}
@@ -72,9 +80,9 @@ func Search(name string) ([]string, error) {
 }
 
 // Exists returns true if the given iterative-dev pack type is valid, false if not
-func Exists(idpName string) (bool, error) {
+func Exists(idpName string, localIndexJSON string) (bool, error) {
 
-	catalogList, err := List()
+	catalogList, err := List(localIndexJSON)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to list catalog")
 	}
@@ -88,8 +96,8 @@ func Exists(idpName string) (bool, error) {
 }
 
 // Get returns the first IDP matching the specified name, if none are found, an error is returned
-func Get(name string) (*CatalogEntry, error) {
-	idpList, err := List()
+func Get(name string, localIndexJSON string) (*CatalogEntry, error) {
+	idpList, err := List(localIndexJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -488,7 +488,7 @@ func CheckComponentMandatoryParams(componentSettings config.ComponentSettings) e
 //	isCmpExistsCheck: boolean to indicate whether or not error out if component with same name already exists
 // Returns:
 //	errors if any
-func ValidateComponentCreateRequest(client *kclient.Client, componentSettings config.ComponentSettings, isCmpExistsCheck bool) (err error) {
+func ValidateComponentCreateRequest(client *kclient.Client, componentSettings config.ComponentSettings, isCmpExistsCheck bool, localIndexJson string) (err error) {
 
 	// Check the mandatory parameters first
 	err = CheckComponentMandatoryParams(componentSettings)
@@ -500,7 +500,7 @@ func ValidateComponentCreateRequest(client *kclient.Client, componentSettings co
 	_, componentType, _, _ := util.ParseComponentImageName(*componentSettings.Type)
 
 	// Check to see if the catalog type actually exists
-	exists, err := catalog.Exists(componentType)
+	exists, err := catalog.Exists(componentType, localIndexJson)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create component of type %s", componentType)
 	}

--- a/pkg/kdo/cli/catalog/list/idp.go
+++ b/pkg/kdo/cli/catalog/list/idp.go
@@ -17,7 +17,8 @@ var idpsExample = `  # Get the supported Iterative-dev Packs`
 // ListIDPOptions encapsulates the options for the udo catalog list idp command
 type ListIDPOptions struct {
 	// list of known images
-	catalogList []catalog.CatalogEntry
+	localIDPRepo string
+	catalogList  []catalog.CatalogEntry
 }
 
 // NewListIDPOptions creates a new ListIDPOptions instance
@@ -27,7 +28,7 @@ func NewListIDPOptions() *ListIDPOptions {
 
 // Complete completes ListIDPOptions after they've been created
 func (o *ListIDPOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
-	o.catalogList, err = catalog.List()
+	o.catalogList, err = catalog.List(o.localIDPRepo)
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func (o *ListIDPOptions) Run() (err error) {
 func NewCmdCatalogListIDPs(name, fullName string) *cobra.Command {
 	o := NewListIDPOptions()
 
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Use:     name,
 		Short:   "List all IDPs available.",
 		Long:    "List all available Iterative-Dev Packs.",
@@ -71,5 +72,10 @@ func NewCmdCatalogListIDPs(name, fullName string) *cobra.Command {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+
+	// Add the flags to the command
+	genericclioptions.AddLocalRepoFlag(&cmd, &o.localIDPRepo)
+
+	return &cmd
 
 }

--- a/pkg/kdo/cli/catalog/search/idp.go
+++ b/pkg/kdo/cli/catalog/search/idp.go
@@ -16,10 +16,9 @@ var idpExample = `  # Search for an iterative-dev pack
 
 // SearchIDPOptions encapsulates the options for the udo catalog search idp command
 type SearchIDPOptions struct {
-	searchTerm string
-	idps       []string
-	// generic context options common to all commands
-	*genericclioptions.Context
+	searchTerm   string
+	localIDPRepo string
+	idps         []string
 }
 
 // NewSearchIDPOptions creates a new SearchIDPOptions instance
@@ -30,7 +29,7 @@ func NewSearchIDPOptions() *SearchIDPOptions {
 // Complete completes SearchIDPOptions after they've been created
 func (o *SearchIDPOptions) Complete(name string, cmd *cobra.Command, args []string) (err error) {
 	o.searchTerm = args[0]
-	o.idps, err = catalog.Search(o.searchTerm)
+	o.idps, err = catalog.Search(o.searchTerm, o.localIDPRepo)
 	return err
 }
 
@@ -55,7 +54,8 @@ func (o *SearchIDPOptions) Run() (err error) {
 // NewCmdCatalogSearchIDP implements the udo catalog search idp command
 func NewCmdCatalogSearchIDP(name, fullName string) *cobra.Command {
 	o := NewSearchIDPOptions()
-	return &cobra.Command{
+
+	cmd := cobra.Command{
 		Use:   name,
 		Short: "Search Iterative-Dev Pack in catalog",
 		Long: `Search Iterative-Dev Pack in catalog.
@@ -69,4 +69,9 @@ Iterative-Dev Packs.
 			genericclioptions.GenericRun(o, cmd, args)
 		},
 	}
+
+	// Adds flags to the command
+	genericclioptions.AddLocalRepoFlag(&cmd, &o.localIDPRepo)
+
+	return &cmd
 }

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -52,6 +52,7 @@ type PushOptions struct {
 	pushConfig bool
 	pushSource bool
 
+	localIDPRepo string
 	*genericclioptions.Context
 }
 
@@ -126,7 +127,7 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Validating component")
 	defer s.End(false)
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfig.GetComponentSettings(), false); err != nil {
+	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfig.GetComponentSettings(), false, po.localIDPRepo); err != nil {
 		return err
 	}
 

--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -127,10 +127,6 @@ func (po *PushOptions) Validate() (err error) {
 	s := log.Spinner("Validating component")
 	defer s.End(false)
 
-	if err = component.ValidateComponentCreateRequest(po.Context.Client, po.localConfig.GetComponentSettings(), false, po.localIDPRepo); err != nil {
-		return err
-	}
-
 	isCmpExists, err := component.Exists(po.Context.Client, po.localConfig.GetName(), po.localConfig.GetApplication())
 	if err != nil {
 		return err

--- a/pkg/kdo/genericclioptions/add_flags.go
+++ b/pkg/kdo/genericclioptions/add_flags.go
@@ -26,3 +26,13 @@ func AddNowFlag(cmd *cobra.Command, setValueTo *bool) {
 		cmd.Flags().Bool("now", false, helpMessage)
 	}
 }
+
+// AddLocalRepoFlag adds 'logal-repo' to the given cobra command, allowing users to pass in a local IDP index.json file
+func AddLocalRepoFlag(cmd *cobra.Command, setValueTo *string) {
+	helpMessage := "Path to a local index.json representing an IDP repo (optional)"
+	if setValueTo != nil {
+		cmd.Flags().StringVar(setValueTo, LocalIDPRepoFlagName, "", helpMessage)
+	} else {
+		cmd.Flags().String(LocalIDPRepoFlagName, "", helpMessage)
+	}
+}

--- a/pkg/kdo/genericclioptions/context_flags.go
+++ b/pkg/kdo/genericclioptions/context_flags.go
@@ -13,4 +13,6 @@ const (
 	OutputFlagName = "output"
 	// ContextFlagName is the name of the flag allowing a user to specify the location of the component settings
 	ContextFlagName = "context"
+	// LocalIDPRepoFlagName is the name of the flag allowing a user to pass in (and use) a local idp repo
+	LocalIDPRepoFlagName = "local-repo"
 )


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Updates the `udo` CLI to support pointing to a local Iterative-Dev Pack repo and to pull IDPs from there instead by adding a `--local-repo` flag.

## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->
N/A

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Git clone the iterative-dev packs repo.
2. `udo catalog list idp --local-repo <index.json>`
3. `udo create nodejs --local-repo <index.json>