### PR TITLE
Add idp to context

### DIFF
--- a/pkg/kdo/cli/component/push.go
+++ b/pkg/kdo/cli/component/push.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/redhat-developer/odo-fork/pkg/component"
 	"github.com/redhat-developer/odo-fork/pkg/config"
-	"github.com/redhat-developer/odo-fork/pkg/idp"
+
 	"github.com/redhat-developer/odo-fork/pkg/kclient"
 	"github.com/redhat-developer/odo-fork/pkg/kdo/genericclioptions"
 
@@ -165,11 +165,6 @@ func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) e
 	// Output the "new" section (applying changes)
 	log.Info("\nConfiguration changes")
 
-	// Get the IDP for the component
-	devPack, err := idp.Get()
-	if err != nil {
-		return errors.Wrapf(err, "unable to read the idp.yaml for %s from disk", cmpName)
-	}
 	// If the component does not exist, we will create it for the first time.
 	if !isCmpExists {
 
@@ -177,7 +172,7 @@ func (po *PushOptions) createCmpIfNotExistsAndApplyCmpConfig(stdout io.Writer) e
 		defer s.End(false)
 
 		// Classic case of component creation
-		if err = component.CreateComponent(po.Context.Client, *po.localConfig, po.componentContext, stdout, devPack); err != nil {
+		if err = component.CreateComponent(po.Context.Client, *po.localConfig, po.componentContext, stdout, po.Context.DevPack); err != nil {
 			log.Errorf(
 				"Failed to create component with name %s. Please use `odo config view` to view settings used to create component. Error: %+v",
 				cmpName,


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Adds the idp to the context so it's readily accessible by any command that uses the component context.

## How to test changes?
<!-- Please describe the steps to test the PR -->
1. Can verify that `udo create` and `udo push` work the same as before